### PR TITLE
[Feat] 페이지 이동 시 스크롤 위치 항상 최상단에 고정시키기

### DIFF
--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,0 +1,12 @@
+import { Outlet, ScrollRestoration } from 'react-router-dom';
+
+const Layout = () => {
+  return (
+    <>
+      <Outlet />
+      <ScrollRestoration />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/pages/mypage/mypageReservationDetail/MypageReservationDetail.tsx
+++ b/src/pages/mypage/mypageReservationDetail/MypageReservationDetail.tsx
@@ -10,7 +10,7 @@ import Text from '@/shared/components/Text/Text';
 import { getStatusMessage } from '@/shared/utils/getStatusMessage';
 import { formatDateTime, getClassStatus } from '@/shared/utils/timeCalculate';
 
-const ClassReservationDetail = () => {
+const MyPageReservationDetail = () => {
   const { id } = useParams<{ id: string }>();
 
   const lessonId = Number(id);
@@ -71,4 +71,4 @@ const ClassReservationDetail = () => {
   );
 };
 
-export default ClassReservationDetail;
+export default MyPageReservationDetail;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -18,83 +18,33 @@ import { CheckoutPage } from '@/pages/reservation/components/TossPayments/CheckO
 import { FailPage } from '@/pages/reservation/components/TossPayments/Fail/Fail';
 import { SuccessPage } from '@/pages/reservation/components/TossPayments/Success/Success';
 import Search from '@/pages/search/Search';
+import Layout from '@/layout/Layout';
 import { ROUTES_CONFIG } from './routesConfig';
 
 export const router = createBrowserRouter([
   {
-    path: ROUTES_CONFIG.home.path,
-    element: <Home />,
-  },
-  {
-    path: ROUTES_CONFIG.login.path,
-    element: <Login />,
-  },
-  {
-    path: ROUTES_CONFIG.auth.path,
-    element: <LoginCallback />,
-  },
-  {
-    path: ROUTES_CONFIG.onboarding.path,
-    element: <Onboarding />,
-  },
-  {
-    path: ROUTES_CONFIG.search.path,
-    element: <Search />,
-  },
-  {
-    path: ROUTES_CONFIG.class.path(':id'),
-    element: <Class />,
-  },
-  {
-    path: ROUTES_CONFIG.dancer.path(':id'),
-    element: <Dancer />,
-  },
-  {
-    path: ROUTES_CONFIG.reservation.path(':id'),
-    element: <Reservation />,
-  },
-  {
-    path: ROUTES_CONFIG.mypageReservation.path,
-    element: <MyPageReservation />,
-  },
-  {
-    path: ROUTES_CONFIG.mypageReservationDetail.path(':id'),
-    element: <MyPageReservationDetail />,
-  },
-  {
-    path: ROUTES_CONFIG.classRegister.path,
-    element: <ClassRegister />,
-  },
-  {
-    path: ROUTES_CONFIG.classRegisterCompletion.path,
-    element: <ClassRegisterCompletion />,
-  },
-  {
-    path: ROUTES_CONFIG.instructorRegister.path,
-    element: <InstructorRegister />,
-  },
-  {
-    path: ROUTES_CONFIG.instructorClassDetail.path(':id'),
-    element: <ClassDetail />,
-  },
-  {
-    path: ROUTES_CONFIG.instructorClassList.path,
-    element: <ClassList />,
-  },
-  {
-    path: ROUTES_CONFIG.payments.path,
-    element: <CheckoutPage />,
-  },
-  {
-    path: ROUTES_CONFIG.paymentsSuccess.path,
-    element: <SuccessPage />,
-  },
-  {
-    path: ROUTES_CONFIG.paymentsFail.path,
-    element: <FailPage />,
-  },
-  {
-    path: '*',
-    element: <Error />,
+    path: '/',
+    element: <Layout />,
+    children: [
+      { path: ROUTES_CONFIG.home.path, element: <Home /> },
+      { path: ROUTES_CONFIG.login.path, element: <Login /> },
+      { path: ROUTES_CONFIG.auth.path, element: <LoginCallback /> },
+      { path: ROUTES_CONFIG.onboarding.path, element: <Onboarding /> },
+      { path: ROUTES_CONFIG.search.path, element: <Search /> },
+      { path: ROUTES_CONFIG.class.path(':id'), element: <Class /> },
+      { path: ROUTES_CONFIG.dancer.path(':id'), element: <Dancer /> },
+      { path: ROUTES_CONFIG.reservation.path(':id'), element: <Reservation /> },
+      { path: ROUTES_CONFIG.mypageReservation.path, element: <MyPageReservation /> },
+      { path: ROUTES_CONFIG.mypageReservationDetail.path(':id'), element: <MyPageReservationDetail /> },
+      { path: ROUTES_CONFIG.classRegister.path, element: <ClassRegister /> },
+      { path: ROUTES_CONFIG.classRegisterCompletion.path, element: <ClassRegisterCompletion /> },
+      { path: ROUTES_CONFIG.instructorRegister.path, element: <InstructorRegister /> },
+      { path: ROUTES_CONFIG.instructorClassDetail.path(':id'), element: <ClassDetail /> },
+      { path: ROUTES_CONFIG.instructorClassList.path, element: <ClassList /> },
+      { path: ROUTES_CONFIG.payments.path, element: <CheckoutPage /> },
+      { path: ROUTES_CONFIG.paymentsSuccess.path, element: <SuccessPage /> },
+      { path: ROUTES_CONFIG.paymentsFail.path, element: <FailPage /> },
+      { path: '*', element: <Error /> },
+    ],
   },
 ]);


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #337 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
### 기존의 문제점
기존에는 페이지 이동 시 스크롤 위치를 그대로 유지하는 문제가 있었습니다. (하단 영상 참고)
그래서 검색페이지에서 수업들이 많이 등록되어있는 경우에, 직접 최상단으로 스크롤을 올려서 확인해야하는 UX를 저해하는 불편함이 있었습니다.

### 🧐왜 이런 문제가 발생했을까?
`React Router`는 기본적으로 페이지 전환 시 스크롤 위치를 그대로 유지한다고 해요.
즉, A페이지 → B페이지로 이동해도 window.scrollY가 300px이면 그 상태로 B 페이지가 렌더링됩니다.
이는 일반적인 SPA(Single Page Application)의 특징이기고 합니다. 페이지가 새로고침되지 않기 때문입니다.

### 해결방법
`React Router`에서는 `ScrollRestoration`을 제공해주고 있습니다. 
`ScrollRestoration`은 페이지 전환 시 스크롤 위치를 자동으로 복원해주는 역할을 합니다.

```
브라우저 '뒤로 가기' / '앞으로 가기'를 할 때
→ 해당 페이지에 있던 스크롤 위치를 복원

일반적인 페이지 전환 시
→ 스크롤을 최상단으로 이동
```

**Layout.tsx**
```js
import { Outlet, ScrollRestoration } from 'react-router-dom';

const Layout = () => {
  return (
    <>
      <Outlet />
      <ScrollRestoration />
    </>
  );
};

export default Layout;
```
다음과 같이 `Layout.tsx`에 `<Outlet />`과 함께 `<ScrollRestoration />`을 구성해주었습니다.
`<ScrollRestoration />`을 추가하게 되면, React Router의 기본 동작(스크롤 유지)을 덮어쓰기 때문에 문제가 해결되게 됩니다.


**아티클**
https://velog.io/@geonhwi1014/React%ED%8E%98%EC%9D%B4%EC%A7%80-%EC%9D%B4%EB%8F%99-%EC%8B%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EC%83%81%EB%8B%A8%EC%9C%BC%EB%A1%9C-%EB%81%8C%EC%96%B4-%EC%98%AC%EB%A6%AC%EA%B8%B0-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EC%9C%84%EC%B9%98-%EB%B3%B5%EC%9B%90


## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->


## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

> ScrollRestoration 적용 전

https://github.com/user-attachments/assets/4a0df15c-e0bd-464a-869d-fc48bc4cf542

> ScrollRestoration 적용 후

https://github.com/user-attachments/assets/02392f7c-6012-4d4e-b27a-8caa09898776


## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->




