### PR TITLE
[Refactor] SP2 로그인, 홈 QA 적용 

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,9 @@
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
-  // <StrictMode>
-  <App />
-  // </StrictMode>
+  <StrictMode>
+    <App />
+  </StrictMode>
 );

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -3,7 +3,6 @@ import HomeCarousel from '@/pages/home/components/HomeCarousel/HomeCarousel';
 import LatestLessons from '@/pages/home/components/LatestLessons/LatestLessons';
 import PopularGenre from '@/pages/home/components/PopularGenre/PopularGenre';
 import UpcomingLessones from '@/pages/home/components/UpcomingLessons/UpcomingLessons';
-import { carouselContainerStyle } from '@/pages/home/home.css';
 
 const images = '/images/image_kkukgirl.webp';
 
@@ -17,9 +16,7 @@ const Home = () => {
 
   return (
     <main>
-      <div className={carouselContainerStyle}>
-        <HomeCarousel />
-      </div>
+      <HomeCarousel />
       <LatestLessons />
       <PopularGenre />
       <UpcomingLessones />

--- a/src/pages/home/apis/queries.ts
+++ b/src/pages/home/apis/queries.ts
@@ -7,6 +7,7 @@ import {
   getPopularGenres,
   getUpcommingLessons,
 } from '@/pages/home/apis/axios';
+import { MAX_POPULAR_GENRE_COUNT } from '@/pages/home/constants';
 import type {
   AdvertisementResponseTypes,
   PopularDancersResponseTypes,
@@ -24,9 +25,20 @@ export const useGetAdvertisements = () => {
 };
 
 export const useGetPopularGenres = () => {
+  // 장르가 3개 미만인 경우 DUMMY 장르 넘겨줌
+  const transformGenres = (data: PopularGenreResponseTypes): PopularGenreResponseTypes => {
+    if (data.genres.length >= MAX_POPULAR_GENRE_COUNT) return data;
+
+    const tempGenres = [...data.genres].concat(
+      Array.from({ length: MAX_POPULAR_GENRE_COUNT - data.genres.length }, () => 'DUMMY')
+    );
+    return { ...data, genres: tempGenres };
+  };
+
   return useQuery<PopularGenreResponseTypes>({
     queryKey: [QUERY_KEYS.LESSONS_POPULAR_GENRES],
     queryFn: () => getPopularGenres(),
+    select: transformGenres,
   });
 };
 

--- a/src/pages/home/components/GenreItem/GenreItem.tsx
+++ b/src/pages/home/components/GenreItem/GenreItem.tsx
@@ -1,4 +1,4 @@
-import { containerStyle, genreStyle, medalStyle } from '@/pages/home/components/GenreItem/genreItem.css';
+import { containerStyle, dummyStyle, genreStyle, medalStyle } from '@/pages/home/components/GenreItem/genreItem.css';
 import Text from '@/shared/components/Text/Text';
 
 interface GenreItemPropTypes {
@@ -8,6 +8,10 @@ interface GenreItemPropTypes {
 }
 
 const GenreItem = ({ medalIcon, genre, onClick }: GenreItemPropTypes) => {
+  if (genre === 'DUMMY') {
+    return <li className={dummyStyle} />;
+  }
+
   return (
     <li className={containerStyle} onClick={onClick}>
       <div className={medalStyle}>{medalIcon}</div>

--- a/src/pages/home/components/GenreItem/genreItem.css.ts
+++ b/src/pages/home/components/GenreItem/genreItem.css.ts
@@ -22,3 +22,13 @@ export const genreStyle = style({
   bottom: '1rem',
   right: '1rem',
 });
+
+export const dummyStyle = style({
+  position: 'relative',
+  width: '100%',
+  maxWidth: '12rem',
+  height: '7.6rem',
+
+  borderRadius: '4px',
+  backgroundColor: vars.colors.gray01,
+});

--- a/src/pages/home/components/LessonItem/LessonItem.tsx
+++ b/src/pages/home/components/LessonItem/LessonItem.tsx
@@ -20,7 +20,6 @@ import Tag from '@/shared/components/Tag/Tag';
 import Text from '@/shared/components/Text/Text';
 import { genreMapping, levelMapping } from '@/shared/constants';
 import { sprinkles } from '@/shared/styles/sprinkles.css';
-import { transformDateToDotFormat } from '@/shared/utils/transformDateToDotFormat';
 
 const LessonItem = ({
   id,
@@ -30,8 +29,7 @@ const LessonItem = ({
   imageUrl,
   teacherProfileImage,
   teacherName,
-  startDate,
-  endDate,
+
   remainingDays,
   useNewStyles = false,
 }: Omit<LessonTypes, 'location'> & { useNewStyles?: boolean }) => {
@@ -82,14 +80,6 @@ const LessonItem = ({
           <div className={sprinkles({ display: 'flex', gap: 6, alignItems: 'center' })}>
             <img src={teacherProfileImage} alt="강사" className={styles.teacherImage} />
             <Text tag="b3_m">{teacherName}</Text>
-          </div>
-        )}
-
-        {startDate && endDate && (
-          <div className={sprinkles({ display: 'flex', gap: 4, alignItems: 'center' })}>
-            <Text tag="c1_r_narrow" color="gray5">
-              {transformDateToDotFormat(startDate)} - {transformDateToDotFormat(endDate)}
-            </Text>
           </div>
         )}
       </div>

--- a/src/pages/home/components/LessonItem/lessonItem.css.ts
+++ b/src/pages/home/components/LessonItem/lessonItem.css.ts
@@ -2,8 +2,8 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/shared/styles/theme.css';
 
 export const classImageStyle = style({
-  width: '16.4rem',
-  height: '9.1rem',
+  minWidth: '16.4rem',
+  height: '12.3rem',
 
   objectFit: 'cover',
   borderRadius: '4px',

--- a/src/pages/home/components/PopularGenre/PopularGenre.tsx
+++ b/src/pages/home/components/PopularGenre/PopularGenre.tsx
@@ -23,12 +23,12 @@ const PopularGenre = () => {
         지금 가장 인기있는 댄스 장르
       </Head>
 
-      <ul className={sprinkles({ display: 'flex', gap: 7, marginTop: 20 })}>
+      <ul className={sprinkles({ display: 'flex', justifyContent: 'space-between', gap: 7, marginTop: 20 })}>
         {data?.genres.map((genre, index) => (
           <GenreItem
-            key={`${index}-${genre}`}
+            key={genre}
             medalIcon={GENRE_ICONS[index]}
-            genre={genreMapping[genre]}
+            genre={genre === 'DUMMY' ? 'DUMMY' : genreMapping[genre]}
             onClick={() => handleGenreClick(genreMapping[genre])}
           />
         ))}

--- a/src/pages/home/components/UpcomingLessons/upcomingLessons.css.ts
+++ b/src/pages/home/components/UpcomingLessons/upcomingLessons.css.ts
@@ -26,5 +26,5 @@ export const titleStyle = style({
 export const deadlineLessonWrapperStyle = style({
   width: '100%',
 
-  marginTop: '6.1rem',
+  marginTop: '3.2rem',
 });

--- a/src/pages/home/constants/index.tsx
+++ b/src/pages/home/constants/index.tsx
@@ -7,3 +7,5 @@ export const GENRE_ICONS = [
   <IcAssetTop2 width={44} height={44} />,
   <IcAssetTop3 width={44} height={44} />,
 ];
+
+export const MAX_POPULAR_GENRE_COUNT = 3;

--- a/src/pages/home/home.css.ts
+++ b/src/pages/home/home.css.ts
@@ -5,10 +5,6 @@ export const containerStyle = style({
   whiteSpace: 'nowrap',
 });
 
-export const carouselContainerStyle = style({
-  minHeight: '37.5rem',
-});
-
 export const rowScrollwrapperStyle = style({
   width: '100%',
 

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,6 +1,6 @@
 import KakaoButton from '@/pages/login/components/KakaoButton/KakaoButton';
 import { containerStyle } from '@/pages/login/login.css';
-import LoginWepm from '@/shared/assets/webm/login.webm';
+import LoginGif from '@/shared/assets/gif/login.gif';
 import Head from '@/shared/components/Head/Head';
 import { sprinkles } from '@/shared/styles/sprinkles.css';
 
@@ -14,9 +14,7 @@ const Login = () => {
         </div>
 
         <div className={sprinkles({ display: 'flex', justifyContent: 'center', width: '100%' })}>
-          <video width={300} autoPlay muted loop>
-            <source src={LoginWepm} type="video/webm" />
-          </video>
+          <img src={LoginGif} width={300} />
         </div>
 
         <KakaoButton />

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -8,15 +8,15 @@ const Login = () => {
   return (
     <>
       <div className={containerStyle}>
+        <div className={sprinkles({ display: 'flex', flexDirection: 'column', width: '100%' })}>
+          <Head tag="h3_sb">댄스 클래스로의 첫 걸음,</Head>
+          <Head tag="h3_sb">지금 시작해 보세요</Head>
+        </div>
+
         <div className={sprinkles({ display: 'flex', justifyContent: 'center', width: '100%' })}>
           <video width={300} autoPlay muted loop>
             <source src={LoginWepm} type="video/webm" />
           </video>
-        </div>
-
-        <div className={sprinkles({ display: 'flex', flexDirection: 'column', width: '100%' })}>
-          <Head tag="h3_sb">댄스 클래스로의 첫 걸음,</Head>
-          <Head tag="h3_sb">지금 시작해 보세요</Head>
         </div>
 
         <KakaoButton />

--- a/src/pages/login/login.css.ts
+++ b/src/pages/login/login.css.ts
@@ -5,5 +5,5 @@ export const containerStyle = style({
   flexDirection: 'column',
   gap: '3.2rem',
 
-  padding: '12.8rem 2rem 8.8rem 2rem',
+  padding: '4.6rem 2rem 6.6rem 2rem',
 });

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -60,3 +60,15 @@ globalStyle('#root', {
 globalStyle('::-webkit-scrollbar', {
   display: 'none',
 });
+
+globalStyle('.swiper-pagination-bullet', {
+  width: '4px',
+  height: '4px',
+  backgroundColor: vars.colors.white50,
+});
+
+globalStyle('.swiper-pagination-bullet:active', {
+  width: '4px',
+  height: '4px',
+  backgroundColor: vars.colors.white,
+});


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #422 


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
QA 대응 해주었습니다! 전체적으로 간단한 디자인 수정이었어요.
누가 (저인거 같긴한데..) strict mode 주석처리해놔서 복구해놨습니다.

또, 로그인 webm이 모바일에서 동영상 플레이어로 재생이 되어서 결국 다시 gif로 바꾸었습니다.. webm 확장자를 어떻게 사용해야 동영상 플레이어 없이 자동재생되는지 아시는 분은 알려주세요ㅠ

## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
인기 장르의 간격을 조정해주었어요. 저는 당연하게도 무조건 3개가 있는건줄 알았는데 1개, 2개인 경우도 있을 수 있다고 해서 3개 미만일때의 뷰를 대응해주었어요. 

기존 뷰
개수가 2개이고 space-between 일때
https://github.com/user-attachments/assets/9e502d97-ecdb-4250-9897-51914a285f8f

개수가 2개이고 flex-start 일때
https://github.com/user-attachments/assets/6656c630-973e-4fec-963d-c1cb76dd9196

위의 영상을 보면 2개일때 반응형을 대응하기가 어려웠어요. 왼쪽으로 고정하면 간격이 안 늘어나고, 양옆으로 고정하면 가운데가 너무 벌어졌거든요.

그래서 응답받은 장르의 개수가 3개 미만일 경우, react-query의 `select` option을 사용하여 'DUMMY' 데이터를 모자란 만큼 채워주었어요. 
react-query의 `select` option은 query 커스텀훅에서 응답받은 data를 가공하여 반환할때 사용해요. 이때 `select`가 반환하는 값이 캐싱이 되는것이 아닌, 원본 data값이 캐싱돼요. 간단한 데이터 가공은 select 선택자를 사용해 주면 데이터 관리에 대한 책임이 query 커스텀 훅으로 넘어가니까 좋은것 같아요! (이 [아티클](https://tkdodo.eu/blog/react-query-data-transformations) 보고 알게되어서 첨부해봐요) 

```ts
export const useGetPopularGenres = () => {
  // 장르가 3개 미만인 경우 DUMMY 장르 넘겨줌
  const transformGenres = (data: PopularGenreResponseTypes): PopularGenreResponseTypes => {
    if (data.genres.length >= MAX_POPULAR_GENRE_COUNT) return data;

    const tempGenres = [...data.genres].concat(
      Array.from({ length: MAX_POPULAR_GENRE_COUNT - data.genres.length }, () => 'DUMMY')
    );
    return { ...data, genres: tempGenres };
  };

  return useQuery<PopularGenreResponseTypes>({
    queryKey: [QUERY_KEYS.LESSONS_POPULAR_GENRES],
    queryFn: () => getPopularGenres(),
    // transformGenres 함수가 반환하는 값 반환 
    select: transformGenres,
  });
};
```

이렇게 모자란 장르는 'DUMMY'로 채워주고, 'DUMMY'일때는 틀만 있는 회색 배경컴포넌트를 만들어줬어요. 
```ts
const GenreItem = ({ medalIcon, genre, onClick }: GenreItemPropTypes) => {
  // 공갈 GenreItem 반환 
  if (genre === 'DUMMY') {
    return <li className={dummyStyle} />;
  }
  // ...
};
```

그리고 감싸는 wrapper 컴포넌트에 space-between 속성으로 430-375 까지 자연스럽게 간격과 너비가 결정되게 해주었어요. 

대응 후
https://github.com/user-attachments/assets/9b8a2b19-018a-4039-b51e-08ecc07d41c0



## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->


## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

