### PR TITLE
[Refactor] search 페이지 tab 상태관리 수정

### DIFF
--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -11,10 +11,12 @@ import Flex from '@/shared/components/Flex/Flex';
 import { genreEngMapping, labelToSortOptionMap, levelEngMapping } from '@/shared/constants';
 import useDebounce from '@/shared/hooks/useDebounce';
 import SearchHeader from './components/SearchHeader/SearchHeader';
+import { useTabNavigation } from './hooks/useTabNavigation';
 
 const Search = () => {
   const location = useLocation();
   const navigate = useNavigate();
+
   const [genre, setGenre] = useState<string | null>(location.state?.genre || null);
 
   if (location.state?.genre) {
@@ -22,6 +24,8 @@ const Search = () => {
   }
 
   const [searchValue, setSearchValue] = useState('');
+
+  const { selectedTab, setSelectedTab } = useTabNavigation();
 
   const [level, setLevel] = useState<string | null>(null);
   const [startDate, setStartDate] = useState('');
@@ -67,6 +71,8 @@ const Search = () => {
         error={error}
         selectedLabel={selectedLabel}
         setSelectedLabel={setSelectedLabel}
+        selectedTab={selectedTab}
+        setSelectedTab={setSelectedTab}
       />
     </Flex>
   );

--- a/src/pages/search/components/TabContainer/TabContainer.tsx
+++ b/src/pages/search/components/TabContainer/TabContainer.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import ClassItem from '@/pages/home/components/LessonItem/LessonItem';
 import type { DefaultSortTagTypes } from '@/pages/home/types/defaultSortTagTypes';
 import DancerList from '@/pages/search/components/TabContainer/DancerList/DancerList';
@@ -48,6 +47,8 @@ interface TabContainerPropTypes {
   error: Error | null;
   selectedLabel: '최신 등록순' | '찜이 많은순' | '마감 임박순';
   setSelectedLabel: (label: '최신 등록순' | '찜이 많은순' | '마감 임박순') => void;
+  selectedTab: number;
+  setSelectedTab: (tab: number) => void;
 }
 
 const TabContainer = ({
@@ -65,9 +66,9 @@ const TabContainer = ({
   classList,
   selectedLabel,
   setSelectedLabel,
+  selectedTab,
+  setSelectedTab,
 }: TabContainerPropTypes) => {
-  const [selectedTab, setSelectedTab] = useState(0);
-
   const handleTagReset = (type: string) => {
     switch (type) {
       case 'genre':

--- a/src/pages/search/components/TabContainer/TabContainer.tsx
+++ b/src/pages/search/components/TabContainer/TabContainer.tsx
@@ -5,6 +5,7 @@ import EmptyView from '@/pages/search/components/TabContainer/EmptyView/EmptyVie
 import Dropdown from '@/pages/search/components/TabContainer/TagSection/Dropdown';
 import TagSection from '@/pages/search/components/TabContainer/TagSection/TagSection';
 import * as styles from '@/pages/search/components/TabContainer/tabContainer.css';
+import { TAB } from '@/pages/search/constants';
 import type { ClassListResponseTypes, DancerListResponseTypes } from '@/pages/search/types/api';
 import IcArrowUnderGray from '@/shared/assets/svg/IcArrowUnderGray';
 import IcXMain04 from '@/shared/assets/svg/IcXMain04';
@@ -47,8 +48,8 @@ interface TabContainerPropTypes {
   error: Error | null;
   selectedLabel: '최신 등록순' | '찜이 많은순' | '마감 임박순';
   setSelectedLabel: (label: '최신 등록순' | '찜이 많은순' | '마감 임박순') => void;
-  selectedTab: number;
-  setSelectedTab: (tab: number) => void;
+  selectedTab: string;
+  setSelectedTab: (tab: string) => void;
 }
 
 const TabContainer = ({
@@ -138,10 +139,16 @@ const TabContainer = ({
         <TabRoot>
           <div className={sprinkles({ display: 'flex', justifyContent: 'space-between' })}>
             <TabList>
-              <TabButton isSelected={selectedTab === 0} onClick={() => setSelectedTab(0)} colorScheme="primary">
+              <TabButton
+                isSelected={selectedTab === TAB.CLASS}
+                onClick={() => setSelectedTab(TAB.CLASS)}
+                colorScheme="primary">
                 클래스
               </TabButton>
-              <TabButton isSelected={selectedTab === 1} onClick={() => setSelectedTab(1)} colorScheme="primary">
+              <TabButton
+                isSelected={selectedTab === TAB.DANCER}
+                onClick={() => setSelectedTab(TAB.DANCER)}
+                colorScheme="primary">
                 댄서
               </TabButton>
             </TabList>
@@ -162,7 +169,7 @@ const TabContainer = ({
             </Dropdown.Root>
           </div>
 
-          <TabPanel isSelected={selectedTab === 0}>
+          <TabPanel isSelected={selectedTab === TAB.CLASS}>
             <TagSection
               displayTags={displayTags}
               activeTags={activeTags}
@@ -185,7 +192,7 @@ const TabContainer = ({
               )}
             </div>
           </TabPanel>
-          <TabPanel isSelected={selectedTab === 1}>
+          <TabPanel isSelected={selectedTab === TAB.DANCER}>
             {error && <div>Error: {error.message}</div>}
             {dancerList && dancerList.teachers && dancerList.teachers.length > 0 ? (
               <DancerList dancers={dancerList.teachers} />

--- a/src/pages/search/constants/index.tsx
+++ b/src/pages/search/constants/index.tsx
@@ -12,3 +12,8 @@ export const SORT_LABELS = {
   MOST_LIKED: '찜이 많은순',
   CLOSING_SOON: '마감 임박순',
 } as const;
+
+export const TAB = {
+  CLASS: 'class',
+  DANCER: 'dancer',
+};

--- a/src/pages/search/hooks/useTabNavigation.ts
+++ b/src/pages/search/hooks/useTabNavigation.ts
@@ -1,24 +1,38 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export const useTabNavigation = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const tabHistoryCountRef = useRef(0);
+  const visitedTabsRef = useRef<Set<string>>(new Set());
+  const initializedRef = useRef(false);
 
-  const selectedTab = parseInt(searchParams.get('tab') || '0', 10);
+  const selectedTab = searchParams.get('tab') || 'class';
 
-  const setSelectedTab = (tab: number) => {
+  if (selectedTab && !visitedTabsRef.current.has(selectedTab)) {
+    visitedTabsRef.current.add(selectedTab);
+  }
+
+  useEffect(() => {
+    if (!initializedRef.current && !searchParams.has('tab')) {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('tab', selectedTab);
+      setSearchParams(newParams, { replace: true });
+      initializedRef.current = true;
+    }
+  }, [searchParams, selectedTab, setSearchParams]);
+
+  const setSelectedTab = (tab: string) => {
     if (selectedTab !== tab) {
       const newParams = new URLSearchParams(searchParams);
-      newParams.set('tab', tab.toString());
+      newParams.set('tab', tab);
 
-      const replaceMode = tabHistoryCountRef.current >= 1;
+      const visited = visitedTabsRef.current.has(tab);
+      visitedTabsRef.current.add(tab);
 
-      if (replaceMode) {
+      if (visited) {
         setSearchParams(newParams, { replace: true });
       } else {
         setSearchParams(newParams);
-        tabHistoryCountRef.current += 1;
       }
     }
   };

--- a/src/pages/search/hooks/useTabNavigation.ts
+++ b/src/pages/search/hooks/useTabNavigation.ts
@@ -1,0 +1,27 @@
+import { useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export const useTabNavigation = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabHistoryCountRef = useRef(0);
+
+  const selectedTab = parseInt(searchParams.get('tab') || '0', 10);
+
+  const setSelectedTab = (tab: number) => {
+    if (selectedTab !== tab) {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('tab', tab.toString());
+
+      const replaceMode = tabHistoryCountRef.current >= 1;
+
+      if (replaceMode) {
+        setSearchParams(newParams, { replace: true });
+      } else {
+        setSearchParams(newParams);
+        tabHistoryCountRef.current += 1;
+      }
+    }
+  };
+
+  return { selectedTab, setSelectedTab };
+};


### PR DESCRIPTION
## 📌 Related Issues
<!--관련 이슈 언급 -->
- close #427  


## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?


## 📄 Tasks
<!-- 작업한 내용을 작성해주세요 -->
QA 사항 중, Search 페이지에서 "댄서" 탭에서 댄서 상세 페이지로 들어갔다가 다시 Search페이지로 돌아와도 "댄서" 탭이 클릭된 상태로 유지하게 해달라는 요청이 있었습니다.

기존에는 다음과 같이
`const [selectedTab, setSelectedTab] = useState(0);`
 `selectedTab` 상태를 `TabContainer`컴포넌트 내부에서 정의하여 사용하고 있었기 때문에, 페이지를 떠났다가 돌아오면 상태가 초기화되고 있었습니다. 해당 문제를 해결하기위한 고민해본 해결 방안은 다음과 같습니다.

1. 로컬 스토리지 사용
2. Location State 사용
3. 전역 상태 활용
4. url 파라미터 활용
5. 상태 보존 라우팅

다섯가지 모두 장단점이 분명하게 존재하고, **url 파라미터**를 활용하는 방법을 최종으로 선택한 이유는 다음과 같습니다.

### 1. 간단하게 구현 가능
- `React Router`의 `useSearchParams` 훅을 사용하면 URL 파라미터를 쉽게 읽고 설정할 수 있습니다. 그래서 별도의 라이브러리를 도입하지 않고도 상태를 관리할 수 있습니다.
### 2. 페이지 새로고침 시 상태 유지
- URL 파라미터를 사용하면 페이지를 새로고침해도 상태가 유지됩니다. 이는 사용자가 예기치 않게 페이지를 새로고침하더라도 이전 상태를 그대로 복원할 수 있게 해줍니다.
- `클래스 탭` : `http://localhost:5173/search?tab=0`, `댄스 탭` : `http://localhost:5173/search?tab=1`
### 3. 직관적인 상태 공유 및 북마킹 가능
- 댄스 탭이 활성화된 상태의 URL을 복사하여 다른 사람에게 전달하면, 받는 사람도 동일한 상태로 페이지를 열 수 있습니다.

## 🧐그럼 다른 문제는 없을까??
브라우저 히스토리가 오염될 가능성이 있었습니다.
탭 상태를 URL 파라미터로 관리하다보니, 브라우저는 탭 변경마다 히스토리에 새 항목이 추가되게 됩니다. 그래서 원하는 페이지로 돌아가려면 여러 번 뒤로가기 필요할 수도 있습니다.
극단적인 예시지만, 사용자가 `클래스 탭`과 `댄스 탭`을 20번 왔다갔다한 상태에서 뒤로가기를 통해서 홈페이지를 가기위해서는 다시 20번의 뒤로가기를 해야했습니다. 

## 해결방법
```ts
import { useRef } from 'react';
import { useSearchParams } from 'react-router-dom';

export const useTabNavigation = () => {
  const [searchParams, setSearchParams] = useSearchParams();
  const tabHistoryCountRef = useRef(0);

  const selectedTab = parseInt(searchParams.get('tab') || '0', 10);

  const setSelectedTab = (tab: number) => {
    if (selectedTab !== tab) {
      const newParams = new URLSearchParams(searchParams);
      newParams.set('tab', tab.toString());

      const replaceMode = tabHistoryCountRef.current >= 1;

      if (replaceMode) {
        setSearchParams(newParams, { replace: true });
      } else {
        setSearchParams(newParams);
        tabHistoryCountRef.current += 1;
      }
    }
  };

  return { selectedTab, setSelectedTab };
};
```
히스토리 스택 크기를 추적하여 최대값에 도달하면 replace: true 옵션을 사용하는 방식으로 해결할 수 있었습니다.

- 초기 탭 첫 번째 변경시: tabHistoryCountRef.current가 0일 경우, setSearchParams(newParams)를 호출하여 브라우저 히스토리에 새 항목을 추가하고, 카운트를 증가.

- 이후 탭 변경: tabHistoryCountRef.current가 1 이상일 경우, setSearchParams(newParams, { replace: true })를 호출하여 현재 히스토리 항목을 대체.

즉, 최초 진입 상태: "클래스" 탭 (히스토리 항목 1개)
첫 탭 변경: "댄서" 탭으로 변경 → 히스토리에 추가 (히스토리 항목 2개)
이후 탭 변경: 모든 변경은 마지막 히스토리 항목을 대체 (히스토리 항목 계속 2개 유지)

다음과 같이 적용하여, 극단적인 탭변경으로 히스토리가 쌓이는 것을 방지할 수 있었습니다.




## ⭐ PR Point (To Reviewer)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->


## 📷 Screenshot
<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

> 기존(댄서 상세 페이지로 이동 후 뒤로가기 시 selectedtab이 "클래스" 탭으로 초기화)

https://github.com/user-attachments/assets/a181163b-d153-41c2-8bc4-718a2e63033c

> 변경(댄서 상세 페이지로 이동 후 뒤로가기 시 selectedtab이 "댄스" 탭으로 유지)

https://github.com/user-attachments/assets/1ff962b3-02f7-4701-9f17-338ded45f61e

> 브라우저 히스토리 스택 최적화

https://github.com/user-attachments/assets/6ab1a68e-b9d2-4cf1-8ff8-647a506e9553




## 🔔 ETC
<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->

