### PR TITLE
[Fix] 검색 페이지 url 히스토리 수정

### DIFF
--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useGetClassList, useGetDancerList } from '@/pages/search/apis/queries';
 import SearchBar from '@/pages/search/components/SearchBar/SearchBar';
 import TabContainer from '@/pages/search/components/TabContainer/TabContainer';
@@ -15,13 +15,8 @@ import { useTabNavigation } from './hooks/useTabNavigation';
 
 const Search = () => {
   const location = useLocation();
-  const navigate = useNavigate();
 
   const [genre, setGenre] = useState<string | null>(location.state?.genre || null);
-
-  if (location.state?.genre) {
-    navigate(location.pathname, { replace: true });
-  }
 
   const [searchValue, setSearchValue] = useState('');
 
@@ -72,7 +67,7 @@ const Search = () => {
         selectedLabel={selectedLabel}
         setSelectedLabel={setSelectedLabel}
         selectedTab={selectedTab}
-        setSelectedTab={setSelectedTab}
+        setSelectedTab={(tab: string) => setSelectedTab(tab)}
       />
     </Flex>
   );

--- a/src/pages/search/Search.tsx
+++ b/src/pages/search/Search.tsx
@@ -67,7 +67,7 @@ const Search = () => {
         selectedLabel={selectedLabel}
         setSelectedLabel={setSelectedLabel}
         selectedTab={selectedTab}
-        setSelectedTab={(tab: string) => setSelectedTab(tab)}
+        setSelectedTab={setSelectedTab}
       />
     </Flex>
   );

--- a/src/pages/search/hooks/useTabNavigation.ts
+++ b/src/pages/search/hooks/useTabNavigation.ts
@@ -1,39 +1,20 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export const useTabNavigation = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const visitedTabsRef = useRef<Set<string>>(new Set());
-  const initializedRef = useRef(false);
 
   const selectedTab = searchParams.get('tab') || 'class';
-
-  if (selectedTab && !visitedTabsRef.current.has(selectedTab)) {
-    visitedTabsRef.current.add(selectedTab);
-  }
-
-  useEffect(() => {
-    if (!initializedRef.current && !searchParams.has('tab')) {
-      const newParams = new URLSearchParams(searchParams);
-      newParams.set('tab', selectedTab);
-      setSearchParams(newParams, { replace: true });
-      initializedRef.current = true;
-    }
-  }, [searchParams, selectedTab, setSearchParams]);
 
   const setSelectedTab = (tab: string) => {
     if (selectedTab !== tab) {
       const newParams = new URLSearchParams(searchParams);
       newParams.set('tab', tab);
 
-      const visited = visitedTabsRef.current.has(tab);
-      visitedTabsRef.current.add(tab);
+      setSearchParams(newParams);
 
-      if (visited) {
-        setSearchParams(newParams, { replace: true });
-      } else {
-        setSearchParams(newParams);
-      }
+      visitedTabsRef.current.add(tab);
     }
   };
 


### PR DESCRIPTION
## 📌 Related Issues
- close #449

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x]  리뷰어와 라벨을 지정했나요?

## 📄 Tasks
기존 검색페이지의 탭별 url 히스토리 스택 관련하여 탭간 이동이 발생해도 브라우저 히스토리에 쌓이도록 변경했습니다.

기존 코드에서는 탭간 이동이 발생해도 브라우저 히스토리에 쌓이지 않지만, 클래스 탭 -> 댄서 탭 -> 클래스 탭인 상황에서 뒤로가기를 2번해야 홈으로 돌아갈 수 있었습니다. 왜냐하면, 이미 방문했던 탭으로 다시 이동할 때 `replace: true` 옵션을 사용하여 현재 히스토리 항목을 대체하게 되는데 해당 부분에서 문제가 발생하게 됩니다.

### 히스토리 플로우
클래스 탭 방문 → 히스토리 스택: [클래스 탭]
댄서 탭 방문 → 히스토리 스택: [클래스 탭, 댄서 탭]
클래스 탭 재방문(replace: true) → 히스토리 스택: [클래스 탭, 클래스 탭] (댄서 탭이 클래스 탭으로 대체됨)
뒤로가기 → 클래스 탭으로 이동 (원래는 댄서 탭이었지만 대체됨)
뒤로가기 → 홈으로 이동

해당문제를 해결하기위해서는 브라우저 히스토리를 조작하기 위해서 추가적인 useEffect 코드가 필요하게 되고(브라우저 히스토리 조작은 사이드 이펙트 이므로), 너무 극단적인 상황을 염두해두고 불필요한 사이드이펙트를 야기할 수 있다고 판단하였습니다. 그래서 기획과 논의하여 브라우저 히스토리를 조작하지 않는 방향으로 수정하도록 하였습니다. 

## ⭐ PR Point 

## 📷 Screenshot

## 🔔 ETC
