### PR TITLE
[Refactor] 2차 QA 수정 반영

### DIFF
--- a/src/pages/editProfiles/components/FormField/FormField.tsx
+++ b/src/pages/editProfiles/components/FormField/FormField.tsx
@@ -1,6 +1,7 @@
 import type { UseFormRegister } from 'react-hook-form';
 import * as styles from '@/pages/editProfiles/components/FormField/formField.css';
 import type { ProfileFormValues } from '@/pages/editProfiles/schema/profileSchema';
+import { allowOnlyNumberKey, allowOnlyNumberPaste } from '@/pages/editProfiles/utils/inputUtils';
 import { MAX_PHONENUMBER_LENGTH, MAX_NAME_LENGTH } from '@/pages/onboarding/constants';
 import Input from '@/shared/components/Input/Input';
 import Text from '@/shared/components/Text/Text';
@@ -30,6 +31,8 @@ const FormField = ({
   onFocus,
   onBlur,
 }: FormFieldPropTypes) => {
+  const isPhoneNumber = name === 'phoneNumber';
+
   return (
     <div className={styles.fieldWrapperStyle}>
       <label>
@@ -43,6 +46,7 @@ const FormField = ({
         readOnly={readOnly}
         onFocus={onFocus}
         onBlur={onBlur}
+        {...(isPhoneNumber && { inputMode: 'numeric', onKeyDown: allowOnlyNumberKey, onPaste: allowOnlyNumberPaste })}
       />
       <div className={styles.errorMessageStyle({ hasError: !!(error && error.message) })}>
         {error?.message && (

--- a/src/pages/editProfiles/components/FormField/FormField.tsx
+++ b/src/pages/editProfiles/components/FormField/FormField.tsx
@@ -27,9 +27,9 @@ const FormField = ({
   error,
   readOnly = false,
   validationMessage,
-  isFocused,
   onFocus,
   onBlur,
+  isFocused,
 }: FormFieldPropTypes) => {
   const isPhoneNumber = name === 'phoneNumber';
 
@@ -44,6 +44,7 @@ const FormField = ({
         isError={!!error}
         maxLength={name === 'phoneNumber' ? MAX_PHONENUMBER_LENGTH : MAX_NAME_LENGTH}
         readOnly={readOnly}
+        isFocused={isFocused}
         onFocus={onFocus}
         onBlur={onBlur}
         {...(isPhoneNumber && { inputMode: 'numeric', onKeyDown: allowOnlyNumberKey, onPaste: allowOnlyNumberPaste })}
@@ -54,7 +55,7 @@ const FormField = ({
             {error.message}
           </Text>
         )}
-        {isFocused && validationMessage}
+        {validationMessage}
       </div>
     </div>
   );

--- a/src/pages/editProfiles/components/ProfileForm/ProfileForm.tsx
+++ b/src/pages/editProfiles/components/ProfileForm/ProfileForm.tsx
@@ -41,14 +41,6 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
     mode: 'onChange',
   });
 
-  const handleFocus = (fieldName: string) => {
-    setFocusedField(fieldName);
-  };
-
-  const handleBlur = () => {
-    setFocusedField(null);
-  };
-
   const { field } = useController({
     name: 'profileImageUrl',
     control,
@@ -98,6 +90,14 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
     editMyProfile(submitData);
   };
 
+  const handleFocus = (fieldName: string) => {
+    setFocusedField(fieldName);
+  };
+
+  const handleBlur = () => {
+    setFocusedField(null);
+  };
+
   const handleSelectImage = () => {
     handleUploaderClick();
   };
@@ -124,9 +124,9 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
           onFocus={() => handleFocus('nickname')}
           onBlur={handleBlur}
           validationMessage={
-            <Text
-              tag="b3_r"
-              color={errors.nickname ? 'alert3' : 'main4'}>{`${nickname?.length || 0}/${MAX_NICKNAME_LENGTH}`}</Text>
+            <Text tag="c1_m" color={errors.nickname ? 'alert3' : focusedField === 'nickname' ? 'main4' : 'gray9'}>
+              {`${nickname?.length || 0}/${MAX_NICKNAME_LENGTH}`}
+            </Text>
           }
         />
 
@@ -140,7 +140,9 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
           onFocus={() => handleFocus('name')}
           onBlur={handleBlur}
           validationMessage={
-            <Text tag="b3_r" color={errors.name ? 'alert3' : 'main4'}>{`${name?.length || 0}/${MAX_NAME_LENGTH}`}</Text>
+            <Text tag="c1_m" color={errors.name ? 'alert3' : focusedField === 'name' ? 'main4' : 'gray9'}>
+              {`${name?.length || 0}/${MAX_NAME_LENGTH}`}
+            </Text>
           }
         />
 
@@ -154,11 +156,9 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
           onFocus={() => handleFocus('phoneNumber')}
           onBlur={handleBlur}
           validationMessage={
-            <Text
-              tag="b3_r"
-              color={
-                errors.phoneNumber ? 'alert3' : 'main4'
-              }>{`${phoneNumber?.length || 0}/${MAX_PHONENUMBER_LENGTH}`}</Text>
+            <Text tag="c1_m" color={errors.phoneNumber ? 'alert3' : focusedField === 'phoneNumber' ? 'main4' : 'gray9'}>
+              {`${phoneNumber?.length || 0}/${MAX_PHONENUMBER_LENGTH}`}
+            </Text>
           }
         />
       </div>

--- a/src/pages/editProfiles/constants/validationMessage.ts
+++ b/src/pages/editProfiles/constants/validationMessage.ts
@@ -7,13 +7,13 @@ export const PROFILE_IMAGE_ERRORS = {
 export const NICKNAME_ERRORS = {
   REQUIRED: '댄서네임을 입력해주세요',
   TOO_LONG: '최대 8자까지 입력 가능합니다',
-  INVALID: '특수기호/띄어쓰기는 입력할 수 없어요',
+  INVALID: '특수기호, 띄어쓰기는 입력할 수 없어요',
 };
 
 export const NAME_ERRORS = {
   REQUIRED: '이름을 입력해주세요',
   TOO_LONG: '최대 8자까지 입력 가능합니다',
-  INVALID: '특수기호/띄어쓰기는 입력할 수 없어요',
+  INVALID: '특수기호, 띄어쓰기는 입력할 수 없어요',
 };
 
 export const PHONE_NUMBER_ERRORS = {

--- a/src/pages/editProfiles/schema/profileSchema.ts
+++ b/src/pages/editProfiles/schema/profileSchema.ts
@@ -30,17 +30,44 @@ export const profileSchema = z.object({
         PROFILE_IMAGE_ERRORS.INVALID_TYPE
       ),
   ]),
-  nickname: z
-    .string()
-    .min(MIN_NICKNAME_LENGTH, NICKNAME_ERRORS.REQUIRED)
-    .max(MAX_NICKNAME_LENGTH, NICKNAME_ERRORS.TOO_LONG)
-    .regex(/^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$/, NICKNAME_ERRORS.INVALID),
+  nickname: z.string().superRefine((val, ctx) => {
+    if (val.length === 0) {
+      ctx.addIssue({ code: 'custom', message: NICKNAME_ERRORS.REQUIRED });
+      return;
+    }
+    if (!/^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$/.test(val)) {
+      ctx.addIssue({ code: 'custom', message: NICKNAME_ERRORS.INVALID });
+      return;
+    }
+    if (val.length < MIN_NICKNAME_LENGTH) {
+      ctx.addIssue({ code: 'custom', message: NICKNAME_ERRORS.REQUIRED });
+      return;
+    }
+    if (val.length > MAX_NICKNAME_LENGTH) {
+      ctx.addIssue({ code: 'custom', message: NICKNAME_ERRORS.TOO_LONG });
+      return;
+    }
+  }),
+
   phoneNumber: z.string().regex(/^[0-9]\d{10}$/, PHONE_NUMBER_ERRORS.INVALID),
-  name: z
-    .string()
-    .min(MIN_NAME_LENGTH, NAME_ERRORS.REQUIRED)
-    .max(MAX_NAME_LENGTH, NAME_ERRORS.TOO_LONG)
-    .regex(/^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$/, NAME_ERRORS.INVALID),
+  name: z.string().superRefine((val, ctx) => {
+    if (val.length === 0) {
+      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.REQUIRED });
+      return;
+    }
+    if (!/^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$/.test(val)) {
+      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.INVALID });
+      return;
+    }
+    if (val.length < MIN_NAME_LENGTH) {
+      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.REQUIRED });
+      return;
+    }
+    if (val.length > MAX_NAME_LENGTH) {
+      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.TOO_LONG });
+      return;
+    }
+  }),
 });
 
 export type ProfileFormValues = z.infer<typeof profileSchema>;

--- a/src/pages/editProfiles/utils/inputUtils.ts
+++ b/src/pages/editProfiles/utils/inputUtils.ts
@@ -1,10 +1,11 @@
-export const allowOnlyNumberKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+import type { KeyboardEvent, ClipboardEvent } from 'react';
+
+export const allowOnlyNumberKey = (e: KeyboardEvent<HTMLInputElement>) => {
   const isNumber =
     (e.key >= '0' && e.key <= '9') || ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'].includes(e.key);
   if (!isNumber) e.preventDefault();
 };
-
-export const allowOnlyNumberPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+export const allowOnlyNumberPaste = (e: ClipboardEvent<HTMLInputElement>) => {
   const paste = e.clipboardData.getData('text');
   if (!/^\d+$/.test(paste)) e.preventDefault();
 };

--- a/src/pages/editProfiles/utils/inputUtils.ts
+++ b/src/pages/editProfiles/utils/inputUtils.ts
@@ -1,0 +1,10 @@
+export const allowOnlyNumberKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const isNumber =
+    (e.key >= '0' && e.key <= '9') || ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'].includes(e.key);
+  if (!isNumber) e.preventDefault();
+};
+
+export const allowOnlyNumberPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+  const paste = e.clipboardData.getData('text');
+  if (!/^\d+$/.test(paste)) e.preventDefault();
+};

--- a/src/pages/instructorRegister/InstructorRegister.tsx
+++ b/src/pages/instructorRegister/InstructorRegister.tsx
@@ -179,12 +179,14 @@ const InstructorRegister = () => {
               </Head>
             </div>
 
-            <ImageUploadSection
-              imgRef={imgRef}
-              previewImg={previewImg}
-              uploadImgFile={uploadImgFile}
-              handleUploaderClick={handleUploaderClick}
-            />
+            <div className={styles.profileImageWrapperStyle}>
+              <ImageUploadSection
+                imgRef={imgRef}
+                previewImg={previewImg}
+                uploadImgFile={uploadImgFile}
+                handleUploaderClick={handleUploaderClick}
+              />
+            </div>
 
             <IntroductionSection register={register} error={errors.detail} detail={detail} />
           </div>

--- a/src/pages/instructorRegister/components/ImageUploadSection/ImageUploadSection.tsx
+++ b/src/pages/instructorRegister/components/ImageUploadSection/ImageUploadSection.tsx
@@ -1,6 +1,6 @@
 import * as styles from '@/pages/instructorRegister/components/ImageUploadSection/imageUploadSection.css';
 import IcCameraMain0624 from '@/shared/assets/svg/IcCameraMain0624';
-import defaultProfile from '/images/image_profile_basic.png';
+import IcProfileBasic from '@/shared/assets/svg/IcProfileBasic';
 
 interface ImageUploadSectionPropTypes {
   handleUploaderClick?: () => void;
@@ -21,8 +21,9 @@ const ImageUploadSection = ({
     <section className={styles.containerStyle} onClick={onClick}>
       <div
         className={styles.previewImgStyle}
-        style={previewImg ? { backgroundImage: `url(${previewImg})` } : { backgroundImage: `url(${defaultProfile})` }}
-        onClick={handleUploaderClick}>
+        onClick={handleUploaderClick}
+        style={previewImg ? { backgroundImage: `url(${previewImg})` } : undefined}>
+        {!previewImg && <IcProfileBasic />}
         <IcCameraMain0624 width={24} height={24} className={styles.icCameraStyle} />
       </div>
 

--- a/src/pages/instructorRegister/instructorRegister.css.ts
+++ b/src/pages/instructorRegister/instructorRegister.css.ts
@@ -31,3 +31,9 @@ export const buttonContainerStyle = style({
   padding: '2.4rem 2rem',
   backgroundColor: vars.colors.white,
 });
+
+export const profileImageWrapperStyle = style({
+  display: 'flex',
+  justifyContent: 'center',
+  width: '100%',
+});

--- a/src/pages/mypage/components/TabWrapper/components/StudentContent/StudentContent.tsx
+++ b/src/pages/mypage/components/TabWrapper/components/StudentContent/StudentContent.tsx
@@ -24,7 +24,7 @@ const StudentContent = () => {
           profileImageUrl={data.profileImageUrl}
           mainText={<Text tag="b1_sb">{data.nickname}</Text>}
           subContent={
-            <Text tag="b3_r" color="gray6">
+            <Text tag="b3_r" color="gray6" className={styles.noUnderlineStyle}>
               {data.name} · {formatPhoneNumberNoSpace(data.phoneNumber)}
             </Text>
           }

--- a/src/pages/mypage/components/TabWrapper/components/StudentContent/studentContent.css.ts
+++ b/src/pages/mypage/components/TabWrapper/components/StudentContent/studentContent.css.ts
@@ -25,3 +25,16 @@ export const menuButtonContainerStyle = style({
 
   backgroundColor: vars.colors.white,
 });
+
+export const noUnderlineStyle = style({
+  textDecoration: 'none',
+  color: 'inherit',
+  pointerEvents: 'none',
+  cursor: 'default',
+
+  selectors: {
+    '&::-webkit-any-link': {
+      textDecoration: 'none',
+    },
+  },
+});

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -3,7 +3,7 @@ import type { ForwardedRef, InputHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import * as style from '@/shared/components/Input/input.css';
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+interface InputPropTypes extends InputHTMLAttributes<HTMLInputElement> {
   isError?: boolean;
   isFocused?: boolean;
   rightAddOn?: ReactNode;
@@ -11,7 +11,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 const Input = (
-  { isError, className, value, rightAddOn, isFocused, onFocusChange, ...props }: InputProps,
+  { isError, className, value, rightAddOn, isFocused, onFocusChange, ...props }: InputPropTypes,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
   const defineInputState = (isError?: boolean, isFocused?: boolean) => {

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -1,36 +1,23 @@
 import clsx from 'clsx';
 import type { ForwardedRef, InputHTMLAttributes, ReactNode } from 'react';
-import { forwardRef, useState } from 'react';
+import { forwardRef } from 'react';
 import * as style from '@/shared/components/Input/input.css';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   isError?: boolean;
+  isFocused?: boolean;
   rightAddOn?: ReactNode;
   onFocusChange?: (isFocused: boolean) => void;
 }
 
 const Input = (
-  { isError, className, value, rightAddOn, onFocusChange, ...props }: InputProps,
+  { isError, className, value, rightAddOn, isFocused, onFocusChange, ...props }: InputProps,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
-  const [isFocused, setIsFocused] = useState(false);
-
-  const handleFocus = () => {
-    setIsFocused(true);
-    onFocusChange?.(true);
-  };
-
-  const handleBlur = () => {
-    setIsFocused(false);
-    onFocusChange?.(false);
-  };
-
   const defineInputState = (isError?: boolean, isFocused?: boolean) => {
-    if (isError) {
-      return 'error';
-    } else if (isFocused) {
-      return 'focus';
-    }
+    if (isError) return 'error';
+    if (isFocused) return 'focus';
+    return undefined;
   };
 
   const inputState = defineInputState(isError, isFocused);
@@ -41,8 +28,6 @@ const Input = (
         ref={ref}
         type="text"
         className={clsx(className, style.inputStyle)}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
         value={value}
         {...props}
         aria-invalid={isError ? 'true' : 'false'}


### PR DESCRIPTION
## 📌 Related Issues
- close #442 

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks
- 프로필 기본 이미지 png -> svg
- 내정보 수정 유효성 관련 피그마에 맞게 수정
- 내정보수정 전화번호 숫자만 입력할 수 있게 수정
- 텍스트 필드 focus 관련 문제 해결 
- 유효성 검사시 첫글자 인식 안되는거 해결

## ⭐ PR Point 
```ts
  name: z.string().superRefine((val, ctx) => {
    if (val.length === 0) {
      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.REQUIRED });
      return;
    }
    if (!/^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]+$/.test(val)) {
      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.INVALID });
      return;
    }
    if (val.length < MIN_NAME_LENGTH) {
      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.REQUIRED });
      return;
    }
    if (val.length > MAX_NAME_LENGTH) {
      ctx.addIssue({ code: 'custom', message: NAME_ERRORS.TOO_LONG });
      return;
    }
  }),
```

닉네임이나 이름 입력 시, 최소 길이와 특수기호 및 공백에 대한 유효성 검사가 겹치면서 에러 메시지가 제대로 출력되지 않는 문제가 있었습니다.
예를 들어, 첫 글자가 띄어쓰기일 경우 이를 인식하지 못했고,
첫 글자가 한 글자만 입력된 경우에는 닉네임 최소 길이 에러 메시지만 출력되었으며,
두 글자 이상부터는 특수기호나 띄어쓰기 여부를 검사하는 로직이 작동했습니다.
이 문제를 해결하기 위해 superRefine 기능을 활용하여 입력값의 상태에 따라 상황별로 적절한 에러 메시지를 개별적으로 처리하도록 구현했습니다.

### 내정보 수정 전화번호 필드 숫자만 받게 수정
React Hook Form은 내부적으로 onChange, onBlur 이벤트를 통해 값을 수직하고 validation을 실행합니다. 
처음에는 정규식(숫자)에 맞지 않으면 value 업데이트 자체를 막는 방식으로 가려고 했었습니다.
```ts
const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
  const value = e.target.value;
  if (/^\d*$/.test(value)) {
    setValue('phoneNumber', value); // react-hook-form 값 업데이트
  }
};
```

대충 위와 같은 식으로 가려고 했습니다. 근데 직접 onChange를 넣으면 react hook form의 register 이벤트 흐름을 덮어쓰기 하게 되면서 의도와는 맞지 않는 결과가 발생했습니다. custom onChange를 쓰려면 register만으로는 어렵기 때문에 Controller를  사용해서 제어하면 좋다는데, 일단 그냥 간단하게 onKeyDown과 onPaste를 사용해서 UX 직관적으로 입력 자체를 막았습니다. 

hook form 공부를 좀 더 해야할거 같으네여 ....


### input 내 focus 문제 해결

input 내 불필요한 focus, blur가 있어서 지우고, 상위에서 준걸로 받게 했습니다. (다른 input 클릭시 해제되게 하기 위해서) isFocused 옵션이 누락되어있어서 추가해서 테두리 뜨게 했습니다 !

### 고민

기획한테 질문은 한 상태인데

https://github.com/user-attachments/assets/287dab80-0588-4182-96e2-a42fd6c9427b

> 현재 닉네임에 오류가 발생한 상태에서 네임이나 전화번호 입력란에 포커스를 옮겨도 닉네임의 오류 상태가 그대로 남아 있습니다. 반면,  error가 없는 input 필드간 focus 해제는 잘 됩니다 !
> 
> 이런 경우, 닉네임처럼 오류가 발생한 입력란은 사용자에게 명확한 피드백을 주기 위해 오류 상태를 계속 유지하는 것이 맞는지, 아니면 다른 입력란으로 포커스가 이동하면 오류 상태를 해제하고 확인버튼 을 누르거나 하려고 할때 다시 띄워줘야하는지 .. 흐음 ...

답 왔는데 에러인건 포커스 유무 상관없이 그냥 계속 보여주는게 맞다네여 ~~ 다행이당 ㅎㅎ




## 📷 Screenshot

## 🔔 ETC
