### PR TITLE
[Refactor] 클래스 등록 페이지 추가 QA사항 반영

### DIFF
--- a/src/pages/instructor/classRegister/components/ClassSchedule/ClassSchedule.tsx
+++ b/src/pages/instructor/classRegister/components/ClassSchedule/ClassSchedule.tsx
@@ -8,6 +8,7 @@ import IcXCircleGray0424 from '@/shared/assets/svg/IcXCircleGray0424';
 import Text from '@/shared/components/Text/Text';
 import { sprinkles } from '@/shared/styles/sprinkles.css';
 import { calculatePeriod, formatDate } from '@/shared/utils/dateCalculate';
+import { formatDuration } from '@/shared/utils/timeUtils';
 
 interface ClassSchedulePropTypes {
   openBottomSheet: () => void;
@@ -43,7 +44,7 @@ const ClassSchedule = ({ openBottomSheet, times, handleRemoveTime }: ClassSchedu
                     {`${calculatePeriod(time.startTime, time.endTime).startTime} ~ ${
                       calculatePeriod(time.startTime, time.endTime).formattedEndTime
                     }`}{' '}
-                    (총 {time.duration} 시간)
+                    ({formatDuration(time.duration)})
                   </Text>
                 </div>
               </div>

--- a/src/pages/instructor/classRegister/components/ClassSchedule/TimeStep/TimeStep.tsx
+++ b/src/pages/instructor/classRegister/components/ClassSchedule/TimeStep/TimeStep.tsx
@@ -15,6 +15,7 @@ import {
   convertToMinutes,
   isTimeOverlapping,
   formatTimeDisplay,
+  getDateWithoutTime,
 } from '@/shared/utils/timeUtils';
 
 interface TimeStepProps {
@@ -42,6 +43,44 @@ const TimeStep = ({
   times = [],
   startDate,
 }: TimeStepProps) => {
+  // 오늘 날짜와 현재 시간 체크
+  const isToday = useMemo(() => {
+    const today = getDateWithoutTime(new Date());
+    const selectedDate = getDateWithoutTime(new Date(startDate));
+    return today.getTime() === selectedDate.getTime();
+  }, [startDate]);
+
+  // 현재 시간 제약 계산 (오늘인 경우)
+  const currentTimeConstraints = useMemo(() => {
+    if (!isToday) return null;
+
+    const now = new Date();
+    // 현재 시간 기준으로 계산
+    const currentHour = now.getHours();
+    const currentMinute = now.getMinutes();
+
+    // 가장 가까운 30분 단위로 계산
+    let nextHour = currentHour;
+    let nextMinute = 0;
+
+    if (currentMinute < 30) {
+      // 30분 미만이면 같은 시간의 30분으로 설정
+      nextMinute = 30;
+    } else {
+      // 30분 이상이면 다음 시간의 00분으로 설정
+      nextHour = currentHour + 1;
+    }
+
+    const display12Hour = nextHour % 12 === 0 ? 12 : nextHour % 12;
+    const nextAmpm = nextHour >= 12 ? 'PM' : 'AM';
+
+    return {
+      hour: display12Hour,
+      minute: nextMinute,
+      ampm: nextAmpm,
+    };
+  }, [isToday]);
+
   // 선택된 날짜에 영향을 미치는 회차의 가장 늦은 종료 시간 찾기
   const latestEndTime = useMemo(() => {
     if (times.length === 0) return null;
@@ -69,25 +108,48 @@ const TimeStep = ({
     return latest;
   }, [times, startDate]);
 
-  // 최소 선택 가능 시간 계산
+  // 최소 선택 가능 시간 계산 (기존 일정 종료 시간과 현재 시간 중 더 늦은 시간)
   const minTimeConstraints = useMemo(() => {
-    if (!latestEndTime) return null;
+    // 가장 늦은 종료 시간 기반 제약
+    let existingConstraint = null;
+    if (latestEndTime) {
+      const minHour = latestEndTime.getHours();
+      const minMinute = latestEndTime.getMinutes();
+      const minAmpm = minHour >= 12 ? 'PM' : 'AM';
+      const display12Hour = minHour % 12 === 0 ? 12 : minHour % 12;
 
-    const minHour = latestEndTime.getHours();
-    const minMinute = latestEndTime.getMinutes();
-    const minAmpm = minHour >= 12 ? 'PM' : 'AM';
-    const display12Hour = minHour % 12 === 0 ? 12 : minHour % 12;
+      existingConstraint = {
+        hour: display12Hour,
+        minute: minMinute,
+        ampm: minAmpm,
+      };
+    }
 
-    return {
-      hour: display12Hour,
-      minute: minMinute,
-      ampm: minAmpm,
-    };
-  }, [latestEndTime]);
+    // 현재 시간 제약이 없으면 기존 제약만 반환
+    if (!currentTimeConstraints) return existingConstraint;
+
+    // 기존 제약이 없으면 현재 시간 제약만 반환
+    if (!existingConstraint) return currentTimeConstraints;
+
+    // 두 제약 조건 중 더 늦은 시간 선택
+    const existingMinutes = convertToMinutes(
+      existingConstraint.hour,
+      existingConstraint.minute,
+      existingConstraint.ampm
+    );
+
+    const currentMinutes = convertToMinutes(
+      currentTimeConstraints.hour,
+      currentTimeConstraints.minute,
+      currentTimeConstraints.ampm
+    );
+
+    return existingMinutes > currentMinutes ? existingConstraint : currentTimeConstraints;
+  }, [latestEndTime, currentTimeConstraints]);
 
   // 현재 시간이 최소 제한 시간보다 이전인지 확인하고 필요시 조정
   const checkAndAdjustTime = () => {
-    if (minTimeConstraints && latestEndTime !== null) {
+    if (minTimeConstraints) {
       // 시간을 분으로 변환하여 비교
       const currentTotalMinutes = convertToMinutes(hour, minute, ampm);
       const minTotalMinutes = convertToMinutes(
@@ -109,7 +171,7 @@ const TimeStep = ({
 
   // 시간 제약 조건이 변경될 때 자동으로 시간 조정
   // 주의: 이 방식은 렌더링마다 실행되지만 조건을 충족할 때만 상태를 변경함
-  if (minTimeConstraints && latestEndTime !== null) {
+  if (minTimeConstraints) {
     checkAndAdjustTime();
   }
 
@@ -161,7 +223,7 @@ const TimeStep = ({
 
   // 시간이 최소 제한 시간보다 이전인지 확인
   const isBeforeMinTime = (newHour: number, newMinute: number, newAmpm: string) => {
-    if (!minTimeConstraints || latestEndTime === null) return false;
+    if (!minTimeConstraints) return false;
 
     // convertToMinutes 함수 사용하여 시간 비교
     const selectedTotalMinutes = convertToMinutes(newHour, newMinute, newAmpm);
@@ -238,16 +300,30 @@ const TimeStep = ({
     ? formatTimeDisplay(minTimeConstraints.hour, minTimeConstraints.minute, minTimeConstraints.ampm)
     : null;
 
+  // 제약 사유 메시지 결정
+  const getConstraintMessage = () => {
+    if (!minTimeConstraints) return null;
+
+    // 기존 일정 제약이 적용된 경우만 메시지 표시
+    if (latestEndTime) {
+      return `이전 회차 종료 시간(${minTimeDisplay}) 이후로만 등록 가능합니다.`;
+    }
+
+    // 현재 시간 제약만 있는 경우 메시지 표시 안함
+    return null;
+  };
+
   return (
     <Flex direction="column">
       <Head level="h2" tag="b1_sb">
         클래스 시작 시간
       </Head>
 
-      {latestEndTime !== null && minTimeDisplay && (
+      {/* 메시지가 있을 경우에만 표시 */}
+      {minTimeConstraints && minTimeDisplay && getConstraintMessage() && (
         <Flex paddingTop="0.8rem">
           <Text tag="b3_r" color="main3">
-            이전 회차 종료 시간({minTimeDisplay}) 이후로만 등록 가능합니다.
+            {getConstraintMessage()}
           </Text>
         </Flex>
       )}

--- a/src/shared/utils/timeUtils.ts
+++ b/src/shared/utils/timeUtils.ts
@@ -113,9 +113,5 @@ export const formatDuration = (duration: number) => {
   const hours = Math.floor(duration);
   const minutes = Math.round((duration - hours) * 60);
 
-  if (minutes === 0) {
-    return `총 ${hours}시간`;
-  } else {
-    return `총 ${hours}시간 ${minutes}분`;
-  }
+  return minutes === 0 ? `총 ${hours}시간` : `총 ${hours}시간 ${minutes}분`;
 };

--- a/src/shared/utils/timeUtils.ts
+++ b/src/shared/utils/timeUtils.ts
@@ -108,3 +108,14 @@ export const formatToISOString = (date: string, hour: number, minute: number, am
     endTime: formatTime(endDate),
   };
 };
+
+export const formatDuration = (duration: number) => {
+  const hours = Math.floor(duration);
+  const minutes = Math.round((duration - hours) * 60);
+
+  if (minutes === 0) {
+    return `총 ${hours}시간`;
+  } else {
+    return `총 ${hours}시간 ${minutes}분`;
+  }
+};


### PR DESCRIPTION
## 📌 Related Issues
- close #457

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks
- 수업 시간 노출 방식 통일
- 당일 수업 등록할 때 현재 시간 이전으로 선택불가하도록 수정

## ⭐ PR Point 
단순 "현재 시간"을 기준으로 반영한 로직이어서 딱히 없습니다.

## 📷 Screenshot
### 기존 UI - 30분 단위일시 ".5"로 표시
<img width="846" alt="스크린샷 2025-05-27 오전 3 10 05" src="https://github.com/user-attachments/assets/c9eef486-27a8-45e5-9eb9-0d2648489d3b" />

### 변경 UI - 30분 단위일시 "~시30분"으로 표시
![스크린샷 2025-05-27 오전 3 09 28](https://github.com/user-attachments/assets/39044c69-657f-4715-b117-80f01ab29cd7)

### 현재 시간 "02:21" 기준, "03:00"부터 선택 가능
![스크린샷 2025-05-27 오전 2 35 10](https://github.com/user-attachments/assets/7cf8cb8f-9987-463f-af18-2e816baaa66d)





## 🔔 ETC
