### PR TITLE
[Feat] Input helperText & length 로직 공통 컴포넌트 내부로 추상화 

### DIFF
--- a/src/pages/editProfiles/components/FormField/FormField.tsx
+++ b/src/pages/editProfiles/components/FormField/FormField.tsx
@@ -2,7 +2,7 @@ import type { UseFormRegister } from 'react-hook-form';
 import * as styles from '@/pages/editProfiles/components/FormField/formField.css';
 import type { ProfileFormValues } from '@/pages/editProfiles/schema/profileSchema';
 import { allowOnlyNumberKey, allowOnlyNumberPaste } from '@/pages/editProfiles/utils/inputUtils';
-import { MAX_PHONENUMBER_LENGTH, MAX_NAME_LENGTH } from '@/pages/onboarding/constants';
+import { MAX_NAME_LENGTH, MAX_PHONENUMBER_LENGTH } from '@/pages/onboarding/constants';
 import Input from '@/shared/components/Input/Input';
 import Text from '@/shared/components/Text/Text';
 
@@ -14,23 +14,11 @@ interface FormFieldPropTypes {
   error?: { message?: string };
   readOnly?: boolean;
   validationMessage?: React.ReactNode;
-  isFocused?: boolean;
-  onFocus?: () => void;
-  onBlur?: () => void;
+  value?: string;
 }
 
-const FormField = ({
-  label,
-  name,
-  placeholder,
-  register,
-  error,
-  readOnly = false,
-  validationMessage,
-  onFocus,
-  onBlur,
-  isFocused,
-}: FormFieldPropTypes) => {
+const FormField = ({ label, name, placeholder, register, error, readOnly = false, value }: FormFieldPropTypes) => {
+  const { ref, onChange } = register(name);
   const isPhoneNumber = name === 'phoneNumber';
 
   return (
@@ -39,24 +27,18 @@ const FormField = ({
         <Text tag="b2_sb">{label}</Text>
       </label>
       <Input
+        ref={ref}
+        onChange={onChange}
+        name={name}
+        value={value}
         placeholder={placeholder}
-        {...register(name)}
         isError={!!error}
         maxLength={name === 'phoneNumber' ? MAX_PHONENUMBER_LENGTH : MAX_NAME_LENGTH}
         readOnly={readOnly}
-        isFocused={isFocused}
-        onFocus={onFocus}
-        onBlur={onBlur}
+        hasLengthNumber={true}
+        helperText={error?.message}
         {...(isPhoneNumber && { inputMode: 'numeric', onKeyDown: allowOnlyNumberKey, onPaste: allowOnlyNumberPaste })}
       />
-      <div className={styles.errorMessageStyle({ hasError: !!(error && error.message) })}>
-        {error?.message && (
-          <Text tag="b3_r" color="alert3">
-            {error.message}
-          </Text>
-        )}
-        {validationMessage}
-      </div>
     </div>
   );
 };

--- a/src/pages/editProfiles/components/ProfileForm/ProfileForm.tsx
+++ b/src/pages/editProfiles/components/ProfileForm/ProfileForm.tsx
@@ -5,14 +5,11 @@ import { usePatchMyProfile } from '@/pages/editProfiles/api/queries';
 import BottomSheet from '@/pages/editProfiles/components/BottomSheet/BottomSheet';
 import FormField from '@/pages/editProfiles/components/FormField/FormField.tsx';
 import * as styles from '@/pages/editProfiles/components/ProfileForm/profileForm.css';
-import { MAX_NAME_LENGTH, MAX_NICKNAME_LENGTH } from '@/pages/editProfiles/constants/limit.ts';
 import type { ProfileFormValues } from '@/pages/editProfiles/schema/profileSchema.ts';
 import { profileSchema } from '@/pages/editProfiles/schema/profileSchema.ts';
 import type { UpdateProfileRequestTypes } from '@/pages/editProfiles/types/api.ts';
 import ImageUploadSection from '@/pages/instructorRegister/components/ImageUploadSection/ImageUploadSection.tsx';
-import { MAX_PHONENUMBER_LENGTH } from '@/pages/onboarding/constants';
 import BoxButton from '@/shared/components/BoxButton/BoxButton';
-import Text from '@/shared/components/Text/Text';
 import useImageUploader from '@/shared/hooks/useImageUploader';
 
 interface ProfileFormPropTypes {
@@ -27,7 +24,6 @@ interface ProfileFormPropTypes {
 const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
   const { mutate: editMyProfile } = usePatchMyProfile();
 
-  const [focusedField, setFocusedField] = useState<string | null>(null);
   const [isImageClick, setIsImageClick] = useState(false);
 
   const {
@@ -91,14 +87,6 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
     editMyProfile(submitData);
   };
 
-  const handleFocus = (fieldName: string) => {
-    setFocusedField(fieldName);
-  };
-
-  const handleBlur = () => {
-    setFocusedField(null);
-  };
-
   const handleSelectImage = () => {
     handleUploaderClick();
   };
@@ -121,14 +109,7 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
           placeholder="댄서네임을 입력해주세요"
           register={register}
           error={errors.nickname}
-          isFocused={focusedField === 'nickname'}
-          onFocus={() => handleFocus('nickname')}
-          onBlur={handleBlur}
-          validationMessage={
-            <Text tag="c1_m" color={errors.nickname ? 'alert3' : focusedField === 'nickname' ? 'main4' : 'gray9'}>
-              {`${nickname?.length || 0}/${MAX_NICKNAME_LENGTH}`}
-            </Text>
-          }
+          value={nickname}
         />
 
         <FormField
@@ -137,14 +118,7 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
           register={register}
           placeholder="이름을 입력해주세요"
           error={errors.name}
-          isFocused={focusedField === 'name'}
-          onFocus={() => handleFocus('name')}
-          onBlur={handleBlur}
-          validationMessage={
-            <Text tag="c1_m" color={errors.name ? 'alert3' : focusedField === 'name' ? 'main4' : 'gray9'}>
-              {`${name?.length || 0}/${MAX_NAME_LENGTH}`}
-            </Text>
-          }
+          value={name}
         />
 
         <FormField
@@ -153,14 +127,7 @@ const ProfileForm = ({ defaultValues }: ProfileFormPropTypes) => {
           placeholder="전화번호를 입력해주세요"
           register={register}
           error={errors.phoneNumber}
-          isFocused={focusedField === 'phoneNumber'}
-          onFocus={() => handleFocus('phoneNumber')}
-          onBlur={handleBlur}
-          validationMessage={
-            <Text tag="c1_m" color={errors.phoneNumber ? 'alert3' : focusedField === 'phoneNumber' ? 'main4' : 'gray9'}>
-              {`${phoneNumber?.length || 0}/${MAX_PHONENUMBER_LENGTH}`}
-            </Text>
-          }
+          value={phoneNumber}
         />
       </div>
 

--- a/src/pages/instructor/classRegister/components/ClassAmount/ClassAmount.tsx
+++ b/src/pages/instructor/classRegister/components/ClassAmount/ClassAmount.tsx
@@ -30,22 +30,16 @@ const ClassAmount = ({ price, register }: ClassAmountPropTypes) => {
   return (
     <div className={sprinkles({ display: 'flex', flexDirection: 'column', gap: 20, width: '100%' })}>
       <Description title="수강료" subTitle={CLASS_AMOUNT_SUBTITLE} />
-      <div className={sprinkles({ display: 'flex', flexDirection: 'column', gap: 4 })}>
-        <Input
-          name={name}
-          ref={ref}
-          placeholder="0"
-          value={price}
-          onChange={handleChange}
-          rightAddOn={<Text tag="b2_sb_long">원</Text>}
-          isError={!!error}
-        />
-        {error && (
-          <Text tag="b3_r" color="alert3">
-            {error.message}
-          </Text>
-        )}
-      </div>
+      <Input
+        name={name}
+        ref={ref}
+        placeholder="0"
+        value={price}
+        onChange={handleChange}
+        rightAddOn={<Text tag="b2_sb_long">원</Text>}
+        isError={!!error}
+        helperText={error?.message}
+      />
     </div>
   );
 };

--- a/src/pages/instructor/classRegister/components/ClassName/ClassName.tsx
+++ b/src/pages/instructor/classRegister/components/ClassName/ClassName.tsx
@@ -1,13 +1,10 @@
-import { useState } from 'react';
 import type { FieldError, UseFormRegister } from 'react-hook-form';
 import { useFormContext } from 'react-hook-form';
-import { nameLengthStyle } from '@/pages/instructor/classRegister/components/ClassName/className.css';
 import Description from '@/pages/instructor/classRegister/components/Description';
 import { MAX_CLASS_NAME_LENGTH } from '@/pages/instructor/classRegister/constants/formLimit';
 import { CLASS_NAME_SUBTITLE } from '@/pages/instructor/classRegister/constants/registerSectionText';
 import type { ClassRegisterFormTypes } from '@/pages/instructor/classRegister/types/classRegisterForm';
 import Input from '@/shared/components/Input/Input';
-import Text from '@/shared/components/Text/Text';
 import { sprinkles } from '@/shared/styles/sprinkles.css';
 
 interface ClassNamePropTypes {
@@ -17,15 +14,10 @@ interface ClassNamePropTypes {
 
 const ClassName = ({ register, className }: ClassNamePropTypes) => {
   const { name, onChange, ref } = register('className');
-  const [isInputFocused, setIsInputFocused] = useState(false);
   const {
     formState: { errors },
   } = useFormContext();
   const error = errors.className as FieldError | undefined;
-
-  const handleFocusChange = (isFocused: boolean) => {
-    setIsInputFocused(isFocused);
-  };
 
   return (
     <div
@@ -37,28 +29,18 @@ const ClassName = ({ register, className }: ClassNamePropTypes) => {
         mb: 20,
       })}>
       <Description title="클래스명" subTitle={CLASS_NAME_SUBTITLE} />
-      <div className={sprinkles({ display: 'flex', flexDirection: 'column', gap: 4 })}>
-        <Input
-          name={name}
-          onChange={onChange}
-          ref={ref}
-          isError={!!error}
-          placeholder="클래스명을 입력해 주세요"
-          maxLength={MAX_CLASS_NAME_LENGTH}
-          onFocusChange={handleFocusChange}
-        />
-        <div className={sprinkles({ display: 'flex', justifyContent: 'space-between' })}>
-          <Text tag="b3_r" color="alert3">
-            {error && error.message}
-          </Text>
-          <Text
-            tag="c1_m"
-            color={error ? 'alert3' : className && isInputFocused ? 'main4' : 'gray9'}
-            className={nameLengthStyle}>
-            {className.length} / {MAX_CLASS_NAME_LENGTH}
-          </Text>
-        </div>
-      </div>
+      <Input
+        name={name}
+        onChange={onChange}
+        ref={ref}
+        isError={!!error}
+        helperText={error?.message}
+        value={className}
+        hasLengthNumber={true}
+        className={sprinkles({ width: '100%' })}
+        placeholder="클래스명을 입력해 주세요"
+        maxLength={MAX_CLASS_NAME_LENGTH}
+      />
     </div>
   );
 };

--- a/src/pages/instructor/classRegister/components/ClassPersonnel/ClassPersonnel.tsx
+++ b/src/pages/instructor/classRegister/components/ClassPersonnel/ClassPersonnel.tsx
@@ -36,22 +36,16 @@ const ClassPersonnel = ({ register, maxReservationCount }: ClassPersonnelPropTyp
         mb: 40,
       })}>
       <Description title="모집 인원" subTitle={CLASS_PERSONNEL_SUBTITLE} />
-      <div className={sprinkles({ display: 'flex', flexDirection: 'column', gap: 4 })}>
-        <Input
-          value={maxReservationCount}
-          name={name}
-          onChange={handleChange}
-          ref={ref}
-          placeholder="0"
-          rightAddOn={<Text tag="b2_sb_long">명</Text>}
-          isError={!!error}
-        />
-        {error && (
-          <Text tag="b3_r" color="alert3">
-            {error.message}
-          </Text>
-        )}
-      </div>
+      <Input
+        value={maxReservationCount}
+        name={name}
+        onChange={handleChange}
+        ref={ref}
+        placeholder="0"
+        rightAddOn={<Text tag="b2_sb_long">명</Text>}
+        isError={!!error}
+        helperText={error?.message}
+      />
     </div>
   );
 };

--- a/src/pages/onboarding/components/ProfileStep/ProfileStep.tsx
+++ b/src/pages/onboarding/components/ProfileStep/ProfileStep.tsx
@@ -78,22 +78,16 @@ const ProfileStep = ({ name, nickname, isNicknameError, changeIsNicknameError, o
         </Flex>
       </Flex>
 
-      <Flex direction="column" gap="0.8rem" marginTop="2.8rem" width="100%">
+      <Flex direction="column" marginTop="2.8rem" width="100%">
         <Input
           isError={isNicknameError}
+          helperText={'특수기호, 띄어쓰기는 입력할 수 없어요'}
           placeholder="댄서네임을 입력하세요"
           value={nickname}
           onChange={(e) => handleNicknameChange(e.target.value)}
+          hasLengthNumber={true}
+          maxLength={MAX_NICKNAME_LENGTH}
         />
-        <Flex width="100%" justify="spaceBetween">
-          <Text tag="b3_r" color="alert3">
-            {isNicknameError ? '특수기호, 띄어쓰기는 입력할 수 없어요' : ''}
-          </Text>
-
-          <Text tag="c1_m" color={isNicknameError ? 'alert3' : 'main4'}>
-            {nickname && `${nickname.length}/${MAX_NICKNAME_LENGTH}`}
-          </Text>
-        </Flex>
       </Flex>
     </Flex>
   );

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -40,7 +40,7 @@ const Input = (
 
   return (
     <div className={style.allContainerStyle}>
-      <div className={style.containerStyle({ defineInputState: inputState })}>
+      <div className={style.containerStyle({ state: inputState })}>
         <input
           ref={ref}
           type="text"
@@ -63,13 +63,13 @@ const Input = (
         )}
         {hasLengthNumber && (
           <div className={style.lengthContainerStyle}>
-            <Text tag="c1_m" className={style.lengthTextStyle({ defineLengthState: lengthState })}>
+            <Text tag="c1_m" className={style.lengthTextStyle({ state: lengthState })}>
               {value ? value.length : 0}
             </Text>
-            <Text tag="c1_m" className={style.lengthTextStyle({ defineLengthState: lengthState })}>
+            <Text tag="c1_m" className={style.lengthTextStyle({ state: lengthState })}>
               /
             </Text>
-            <Text tag="c1_m" className={style.lengthTextStyle({ defineLengthState: lengthState })}>
+            <Text tag="c1_m" className={style.lengthTextStyle({ state: lengthState })}>
               {maxLength}
             </Text>
           </div>

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -19,9 +19,6 @@ const Input = (
 ) => {
   const [isFocused, setIsFocused] = useState(false);
 
-  const handleFocus = () => setIsFocused(true);
-  const handleBlur = () => setIsFocused(false);
-
   const defineInputState = (isError?: boolean, isFocused?: boolean) => {
     if (isError) return 'error';
     if (isFocused) return 'focus';
@@ -46,8 +43,8 @@ const Input = (
           type="text"
           value={value}
           className={clsx(className, style.inputStyle)}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
           maxLength={maxLength}
           aria-invalid={isError ? 'true' : 'false'}
           {...props}

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -44,10 +44,11 @@ const Input = (
         <input
           ref={ref}
           type="text"
+          value={value}
           className={clsx(className, style.inputStyle)}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          value={value}
+          maxLength={maxLength}
           aria-invalid={isError ? 'true' : 'false'}
           {...props}
         />

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -1,38 +1,79 @@
 import clsx from 'clsx';
 import type { ForwardedRef, InputHTMLAttributes, ReactNode } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import * as style from '@/shared/components/Input/input.css';
+import Text from '@/shared/components/Text/Text';
 
 interface InputPropTypes extends InputHTMLAttributes<HTMLInputElement> {
   isError?: boolean;
-  isFocused?: boolean;
   rightAddOn?: ReactNode;
-  onFocusChange?: (isFocused: boolean) => void;
+  helperText?: string;
+  hasLengthNumber?: boolean;
+  value?: string;
+  maxLength?: number;
 }
 
 const Input = (
-  { isError, className, value, rightAddOn, isFocused, onFocusChange, ...props }: InputPropTypes,
+  { isError, className, value, rightAddOn, helperText, hasLengthNumber, maxLength, ...props }: InputPropTypes,
   ref: ForwardedRef<HTMLInputElement>
 ) => {
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleFocus = () => setIsFocused(true);
+  const handleBlur = () => setIsFocused(false);
+
   const defineInputState = (isError?: boolean, isFocused?: boolean) => {
     if (isError) return 'error';
     if (isFocused) return 'focus';
     return undefined;
   };
 
+  const defineLengthState = (isError?: boolean, isFocused?: boolean) => {
+    if (isError) return 'error';
+    if (isFocused) return 'focus';
+    if (value && value.length > 0) return 'filled';
+    return undefined;
+  };
+
   const inputState = defineInputState(isError, isFocused);
+  const lengthState = defineLengthState(isError, isFocused);
 
   return (
-    <div className={style.containerStyle({ defineInputState: inputState })}>
-      <input
-        ref={ref}
-        type="text"
-        className={clsx(className, style.inputStyle)}
-        value={value}
-        {...props}
-        aria-invalid={isError ? 'true' : 'false'}
-      />
-      {rightAddOn}
+    <div className={style.allContainerStyle}>
+      <div className={style.containerStyle({ defineInputState: inputState })}>
+        <input
+          ref={ref}
+          type="text"
+          className={clsx(className, style.inputStyle)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          value={value}
+          aria-invalid={isError ? 'true' : 'false'}
+          {...props}
+        />
+        {rightAddOn}
+      </div>
+
+      <div className={style.optionalContainerStyle}>
+        {isError && helperText && (
+          <Text tag="b3_r" color="alert3">
+            {helperText}
+          </Text>
+        )}
+        {hasLengthNumber && (
+          <div className={style.lengthContainerStyle}>
+            <Text tag="c1_m" className={style.lengthTextStyle({ defineLengthState: lengthState })}>
+              {value ? value.length : 0}
+            </Text>
+            <Text tag="c1_m" className={style.lengthTextStyle({ defineLengthState: lengthState })}>
+              /
+            </Text>
+            <Text tag="c1_m" className={style.lengthTextStyle({ defineLengthState: lengthState })}>
+              {maxLength}
+            </Text>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/shared/components/Input/Input.tsx
+++ b/src/shared/components/Input/Input.tsx
@@ -39,6 +39,7 @@ const Input = (
     <div className={style.allContainerStyle}>
       <div className={style.containerStyle({ state: inputState })}>
         <input
+          {...props}
           ref={ref}
           type="text"
           value={value}
@@ -47,7 +48,6 @@ const Input = (
           onBlur={() => setIsFocused(false)}
           maxLength={maxLength}
           aria-invalid={isError ? 'true' : 'false'}
-          {...props}
         />
         {rightAddOn}
       </div>

--- a/src/shared/components/Input/input.css.ts
+++ b/src/shared/components/Input/input.css.ts
@@ -2,6 +2,13 @@ import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { vars } from '@/shared/styles/theme.css';
 
+export const allContainerStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.4rem',
+  width: '100%',
+});
+
 export const containerStyle = recipe({
   base: {
     display: 'flex',
@@ -33,5 +40,36 @@ export const inputStyle = style({
 
   '::placeholder': {
     color: vars.colors.gray05,
+  },
+});
+
+export const optionalContainerStyle = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  width: '100%',
+});
+
+export const lengthContainerStyle = style({
+  display: 'flex',
+  gap: '0.2rem',
+  marginLeft: 'auto',
+});
+
+export const lengthTextStyle = recipe({
+  base: {
+    color: vars.colors.gray04,
+  },
+  variants: {
+    defineLengthState: {
+      focus: {
+        color: vars.colors.main04,
+      },
+      error: {
+        color: vars.colors.alert03,
+      },
+      filled: {
+        color: vars.colors.gray09,
+      },
+    },
   },
 });

--- a/src/shared/components/Input/input.css.ts
+++ b/src/shared/components/Input/input.css.ts
@@ -23,7 +23,7 @@ export const containerStyle = recipe({
     backgroundColor: vars.colors.gray01,
   },
   variants: {
-    defineInputState: {
+    state: {
       focus: {
         outline: `1px solid ${vars.colors.main04}`,
       },
@@ -60,7 +60,7 @@ export const lengthTextStyle = recipe({
     color: vars.colors.gray04,
   },
   variants: {
-    defineLengthState: {
+    state: {
       focus: {
         color: vars.colors.main04,
       },


### PR DESCRIPTION
## 📌 Related Issues
- close #466 

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks
Input 공통 컴포넌트에서 `helperText` & `length` 로직을 내부로 추상화했어요.


## ⭐ PR Point 
이전부터 나온 문제였지만 조금 수정이 늦었습니다. 해당 작업 반영 전까지 Input 공통 컴포넌트를 사용할 때 다음과 같은 불편함이 있었어요.

1. 에러 상태에 따른 `helperText`(ex. error 메시지) 스타일 분기 처리 로직 작성 필요
2. 에러 상태에 따른 글자 수 스타일 분기 처리 로직 작성 필요

<br/>


<img width="400" alt="image" src="https://github.com/user-attachments/assets/a2db7ceb-2d41-4188-8916-b8f931a34ab2" />

<br/>
<br/>

쉽게 말해 위 사진처럼 `helperText`와 글자 수 text 모두 `default/error/focus` 등의 상태에 따라 스타일 분기가 되어야 했어요. 하지만 Input 공통 컴포넌트 내부에는 Input과 그 테두리만 포함된 상태로 구현이 되어있었기 때문에, 해당 2개의 상태 분기를 Input을 사용하는 모든 곳에서 다 정의해줘야 하는 불편함이 있었어요.

즉 `focus/blur`와 같은 상태 로직 등 동일한 로직을 매번 정의해야 하는 것이 문제였으니 반대로 이것을 중앙화해서 한 곳에서 관리하면 해결이 될 문제라고 생각했어요.

만약 text 스타일을 결정하는 상태가 input 테두리 색을 결정하는 상태와 다르게 작동해야 했다면 현재처럼 분리해서 사용하는 곳에서 해당 상태를 정의하는 것이 맞았겠지만, 동일했기 때문에 더욱더 수정하는 방향이 맞다고 판단했어요.

따라서 `defineInputState`와 `defineLengthState`함수로 상태를 결정하고 해당 상태를 recipe를 통해 스타일을 분기하도록 하였고, Input 내부에서 `optional`한 text를 책임지도록 수정했어요!

<br/>

### 🤔 조언을 받고 싶은 점
지금도 잘 작동하고 괜찮은 로직이라고 생각했지만, 설계를 하면서 조금 고민이 되는 부분이 있었어요.

input 테두리 상태를 결정하는 defineInputState와 글자 수 text 상태를 결정하는 defineLengthState가 거의 비슷한데 나눈 이유가 글자 수 text에서는 값이 채워지고 안채워지고의 fill 여부에 따라서도 스타일 분기가 있어야 하는 점이 차이가 있어요.

그래서 두 개의 로직을 따로 분리했는데 더 좋은 방법이 있을지, 그리고 애초에 해당 스타일 분기 방법이 괜찮은 방법일지 조금 고민이 됩니다! 

그리고 아래 사진과 같이Input에도 글자 수가 있고 없고, helperText가 있고 없고 등이 여러가지 case로 조합되어 있어요. 

<br/>
<img width="1015" height="779" alt="image" src="https://github.com/user-attachments/assets/b6645078-60d8-4fcb-96c7-ad8213887b2c" />

<br/>

그래서 생각보다 `hasLengthNumber`등의 props로 여러 type을 구분 사용할 수 있도록 구현했는데, 이것이 추상화 관점에서 괜찮을지 고민이 됩니다! 이정도면 괜찮을지 아니면 오히려 이 정도면 **다른 Input으로 컴포넌트를 분리**해서 역할을 확실히 해야 할지 조금 고민이 돼서 해당 부분에 대해서 의견이 있다면 조언 주시면 감사하겠습니다 👍  

<br/>


## 📷 Screenshot

## 🔔 ETC
