### PR TITLE
[Feat] Onboarding 정보 전송 & 인증번호 전송 api 연결

### DIFF
--- a/src/pages/instructor/lessonManage/LessonManage.tsx
+++ b/src/pages/instructor/lessonManage/LessonManage.tsx
@@ -3,7 +3,7 @@ import LessonList from '@/pages/instructor/lessonList/LessonList';
 import { useGetLessonStatus } from '@/pages/instructor/lessonList/apis/queries';
 import type { LessonStatus } from '@/pages/instructor/lessonList/types/lessonStatus';
 import * as styles from '@/pages/instructor/lessonManage/lessonManage.css';
-import Dropdown from '@/common/components/Dropdown';
+import Dropdown from '@/common/components/Dropdown/Dropdown';
 import Head from '@/shared/components/Head/Head';
 import { sprinkles } from '@/shared/styles/sprinkles.css';
 

--- a/src/pages/onboarding/Onboarding.tsx
+++ b/src/pages/onboarding/Onboarding.tsx
@@ -11,8 +11,6 @@ import type { OnboardInfoTypes, OnboardingState } from '@/pages/onboarding/types
 import { ROUTES_CONFIG } from '@/routes/routesConfig';
 import { useFunnel } from '@/shared/hooks/useFunnel';
 import { setStorage } from '@/shared/utils/handleToken';
-import { notify } from '@/shared/components/Toast/Toast';
-
 
 const Onboarding = () => {
   const { Funnel, Step, setStep, currentStep } = useFunnel(FINAL_ONBOARDING_STEP, ROUTES_CONFIG.home.path);
@@ -49,12 +47,6 @@ const Onboarding = () => {
     e.preventDefault();
     setOnboarding((prev) => ({ ...prev, isSubmitting: true }));
 
-    if (!onboarding.isCodeVerified) {
-       notify({ message: '휴대폰 인증을 먼저 완료해주세요', icon: 'fail', bottomGap: 'large' });
-       setOnboarding((prev) => ({ ...prev, isSubmitting: false }));
-       return;
-    }
-
     onboardMutate(
       {
         ...onboarding.info,
@@ -64,9 +56,6 @@ const Onboarding = () => {
         onSuccess: () => {
             setStorage(tokenRef.current.accessToken, tokenRef.current.refreshToken);
             setStep(1);
-        },
-        onError: () => {
-           notify({ message: '정보 등록에 실패했어요. 다시 시도해주세요.', icon: 'fail', bottomGap: 'large' });
         },
         onSettled: () => {
             setOnboarding((prev) => ({ ...prev, isSubmitting: false }));

--- a/src/pages/onboarding/Onboarding.tsx
+++ b/src/pages/onboarding/Onboarding.tsx
@@ -54,18 +54,25 @@ const Onboarding = () => {
       },
       {
         onSuccess: () => {
-            setStorage(tokenRef.current.accessToken, tokenRef.current.refreshToken);
-            setStep(1);
+          setStorage(tokenRef.current.accessToken, tokenRef.current.refreshToken);
+          setStep(1);
         },
         onSettled: () => {
-            setOnboarding((prev) => ({ ...prev, isSubmitting: false }));
-        }
+          setOnboarding((prev) => ({ ...prev, isSubmitting: false }));
+        },
       }
     );
   };
 
   return (
-    <form className={styles.containerStyle} onSubmit={handleOnboardSubmit}>
+    <form
+      className={styles.containerStyle}
+      onSubmit={handleOnboardSubmit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+        }
+      }}>
       <OnboardingHeader step={currentStep} />
       <div className={styles.bodyWrapperStyle}>
         <Funnel>

--- a/src/pages/onboarding/apis/axios.ts
+++ b/src/pages/onboarding/apis/axios.ts
@@ -1,5 +1,5 @@
 import type { tokenTypes } from '@/pages/onboarding/types/api';
-import type { OnboardInfoTypes } from '@/pages/onboarding/types/onboardInfoTypes';
+import type { OnboardInfoTypes, PhoneRequestTypes, phoneVerifyTypes } from '@/pages/onboarding/types/onboardInfoTypes';
 import { instance } from '@/shared/apis/instance';
 import { API_URL } from '@/shared/constants/apiURL';
 
@@ -18,4 +18,37 @@ export const postOnboard = async ({ name, phoneNumber, accessToken }: OnboardInf
   );
 
   return { response };
+};
+
+export const postPhoneRequest = async({phoneNumber, accessToken} : PhoneRequestTypes & tokenTypes) => {
+  const response = await instance.post(
+    API_URL.AUTH_PHONE_REQUEST,
+    {
+      phoneNumber,
+    },
+        {
+      headers: { 
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  )
+
+  return {response}
+}
+
+export const postPhoneVerify = async ({ phoneNumber, code, accessToken }: phoneVerifyTypes & tokenTypes) => {
+  const response = await instance.post(
+    API_URL.AUTH_PHONE_VERIFY, 
+    {
+      phoneNumber,
+      code,
+    },
+    {
+      headers: { 
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+
+  return response.data; 
 };

--- a/src/pages/onboarding/apis/queries.ts
+++ b/src/pages/onboarding/apis/queries.ts
@@ -5,6 +5,7 @@ import type { tokenTypes } from '@/pages/onboarding/types/api';
 import type { OnboardInfoTypes, PhoneRequestTypes, phoneVerifyTypes } from '@/pages/onboarding/types/onboardInfoTypes';
 import { notify } from '@/shared/components/Toast/Toast';
 import { PHONE_AUTH_MESSAGES } from '@/pages/onboarding/constants';
+import { ApiError } from '@/shared/types/api';
 
 export const usePostOnboard = () => {
   return useMutation({
@@ -44,7 +45,7 @@ export const usePostPhoneVerify = () => {
         code,
         accessToken,
       }),
-    onError: (error: AxiosError) => {
+    onError: (error: AxiosError<ApiError>) => {
       if (!error.response) return;
       notify({message: PHONE_AUTH_MESSAGES.CODE_MISMATCH, icon: 'fail', bottomGap: 'large'})
     },

--- a/src/pages/onboarding/apis/queries.ts
+++ b/src/pages/onboarding/apis/queries.ts
@@ -3,6 +3,8 @@ import type { AxiosError } from 'axios';
 import { postOnboard, postPhoneRequest, postPhoneVerify } from '@/pages/onboarding/apis/axios';
 import type { tokenTypes } from '@/pages/onboarding/types/api';
 import type { OnboardInfoTypes, PhoneRequestTypes, phoneVerifyTypes } from '@/pages/onboarding/types/onboardInfoTypes';
+import { notify } from '@/shared/components/Toast/Toast';
+import { PHONE_AUTH_MESSAGES } from '@/pages/onboarding/constants';
 
 export const usePostOnboard = () => {
   return useMutation({
@@ -29,7 +31,7 @@ export const usePostPhoneRequest = () => {
       }),
     onError: (error: AxiosError) => {
       if (!error.response) return;
-      console.log('인증번호 요청 실패:', error);
+      notify({message: PHONE_AUTH_MESSAGES.SEND_FAILED, icon: 'fail', bottomGap: 'large'})
     },
   });
 };
@@ -44,7 +46,7 @@ export const usePostPhoneVerify = () => {
       }),
     onError: (error: AxiosError) => {
       if (!error.response) return;
-      console.log('인증번호 확인 실패:', error);
+      notify({message: PHONE_AUTH_MESSAGES.CODE_MISMATCH, icon: 'fail', bottomGap: 'large'})
     },
   });
 };

--- a/src/pages/onboarding/apis/queries.ts
+++ b/src/pages/onboarding/apis/queries.ts
@@ -1,8 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
-import { postOnboard } from '@/pages/onboarding/apis/axios';
+import { postOnboard, postPhoneRequest, postPhoneVerify } from '@/pages/onboarding/apis/axios';
 import type { tokenTypes } from '@/pages/onboarding/types/api';
-import type { OnboardInfoTypes } from '@/pages/onboarding/types/onboardInfoTypes';
+import type { OnboardInfoTypes, PhoneRequestTypes, phoneVerifyTypes } from '@/pages/onboarding/types/onboardInfoTypes';
 
 export const usePostOnboard = () => {
   return useMutation({
@@ -16,6 +16,35 @@ export const usePostOnboard = () => {
     onError: (error: AxiosError) => {
       if (!error.response) return;
       console.log(error);
+    },
+  });
+};
+
+export const usePostPhoneRequest = () => {
+  return useMutation({
+    mutationFn: ({ phoneNumber, accessToken }: PhoneRequestTypes & tokenTypes) =>
+      postPhoneRequest({
+        phoneNumber,
+        accessToken,
+      }),
+    onError: (error: AxiosError) => {
+      if (!error.response) return;
+      console.log('인증번호 요청 실패:', error);
+    },
+  });
+};
+
+export const usePostPhoneVerify = () => {
+  return useMutation({
+    mutationFn: ({ phoneNumber, code, accessToken }: phoneVerifyTypes & tokenTypes) =>
+      postPhoneVerify({
+        phoneNumber,
+        code,
+        accessToken,
+      }),
+    onError: (error: AxiosError) => {
+      if (!error.response) return;
+      console.log('인증번호 확인 실패:', error);
     },
   });
 };

--- a/src/pages/onboarding/components/InfoStep/InfoStep.tsx
+++ b/src/pages/onboarding/components/InfoStep/InfoStep.tsx
@@ -18,7 +18,6 @@ import Head from '@/shared/components/Head/Head';
 import Input from '@/shared/components/Input/Input';
 import Text from '@/shared/components/Text/Text';
 import { notify } from '@/shared/components/Toast/Toast';
-import type { ApiError } from '@/shared/types/api';
 
 interface InfoStepProps {
   name: string;
@@ -106,14 +105,13 @@ const InfoStep = ({
           setIsCodeVerified(true);
           resetTimer();
         },
-          onError: (error) => {
-           const apiError = error.response?.data as ApiError;
-           if (error.response?.status === 409) {
+        onError: (error) => { 
+          if (error.response?.status === 409) {
             notify({ message: PHONE_AUTH_MESSAGES.CODE_MISMATCH, icon: 'fail', bottomGap: 'large' });
-           } else {
-             const message = apiError?.message || PHONE_AUTH_MESSAGES.TRY_AGAIN;
-             notify({ message, icon: 'fail', bottomGap: 'large' });
-           }
+          } else {
+            const message = error.response?.data?.message || PHONE_AUTH_MESSAGES.TRY_AGAIN;
+            notify({ message, icon: 'fail', bottomGap: 'large' });
+          }
           setIsCodeVerified(false);
         },
       }

--- a/src/pages/onboarding/components/InfoStep/InfoStep.tsx
+++ b/src/pages/onboarding/components/InfoStep/InfoStep.tsx
@@ -173,7 +173,7 @@ const InfoStep = ({
           {isVerificationVisible && (
             <div className={styles.numberWrapperStyle}>
               <Input
-                placeholder="인증번호 6자리"
+                placeholder={`인증번호 ${MAX_VERIFICATION_CODE}자리`}
                 value={verificationCode}
                 onChange={(e) => handleVerificationCodeChange(e.target.value)}
                 rightAddOn={

--- a/src/pages/onboarding/components/InfoStep/InfoStep.tsx
+++ b/src/pages/onboarding/components/InfoStep/InfoStep.tsx
@@ -169,7 +169,7 @@ const InfoStep = ({
           {isVerificationVisible && (
             <div className={styles.numberWrapperStyle}>
               <Input
-                placeholder="인증번호 4자리"
+                placeholder="인증번호 6자리"
                 value={verificationCode}
                 onChange={(e) => handleVerificationCodeChange(e.target.value)}
                 rightAddOn={

--- a/src/pages/onboarding/components/InfoStep/InfoStep.tsx
+++ b/src/pages/onboarding/components/InfoStep/InfoStep.tsx
@@ -4,7 +4,8 @@ import * as styles from '@/pages/onboarding/components/InfoStep/infoStep.css';
 import {
   INFO_KEY,
   MAX_PHONENUMBER_LENGTH,
-  MAX_VERFICATION_CODE,
+  MAX_VERIFICATION_CODE,
+  MAX_VERIFICATION_NUMBER,
   PHONE_AUTH_MESSAGES,
   REQUEST_DELAY,
   TIMER_DURATION,
@@ -57,7 +58,7 @@ const InfoStep = ({
 
   const handleVerificationCodeChange = (value: string) => {
     const onlyNumbers = value.replace(/\D/g, '');
-    if (onlyNumbers.length <= MAX_VERFICATION_CODE) {
+    if (onlyNumbers.length <= MAX_VERIFICATION_CODE) {
       onInfoChange(INFO_KEY.VERIFICATION_CODE, onlyNumbers);
     }
   };
@@ -69,7 +70,7 @@ const InfoStep = ({
       notify({ message: PHONE_AUTH_MESSAGES.TRY_AGAIN, icon: 'fail', bottomGap: 'large' });
       return;
     }
-    if (requestCount >= 5) {
+    if (requestCount >= MAX_VERIFICATION_NUMBER) {
       notify({ message: PHONE_AUTH_MESSAGES.LIMIT_EXCEEDED, icon: 'fail', bottomGap: 'large' });
       return;
     }
@@ -127,7 +128,7 @@ const InfoStep = ({
   };
 
   const isRequestDisabled = phoneNumber.length !== MAX_PHONENUMBER_LENGTH || isCodeVerified;
-  const isVerifyButtonDisabled = verificationCode.length !== MAX_VERFICATION_CODE;
+  const isVerifyButtonDisabled = verificationCode.length !== MAX_VERIFICATION_CODE;
   const showAsResend = isRunning || isCodeVerified;
 
   return (

--- a/src/pages/onboarding/constants/index.ts
+++ b/src/pages/onboarding/constants/index.ts
@@ -43,3 +43,15 @@ export const FINAL_ONBOARDING_STEP = 2;
 export const TIMER_DURATION = 300;
 
 export const REQUEST_DELAY = 10;
+
+// 인증번호 관련 유즈케이스 에러메세지
+export const PHONE_AUTH_MESSAGES = {
+  TRY_AGAIN: '잠시 후 다시 요청해주세요',
+  CODE_MISMATCH: '인증번호가 일치하지 않아요',
+  ALREADY_VERIFIED: '이미 인증이 완료되었어요',
+  DUPLICATE_PHONE: '이미 등록된 전화번호에요',
+  LIMIT_EXCEEDED: '인증 요청은 하루에 5회까지만 가능해요',
+  SEND_FAILED: '인증번호 전송에 실패했어요',
+  VERIFIED_SUCCESS: '전화번호 인증이 완료되었어요',
+  CODE_SENT: '인증번호가 전송되었습니다',
+} as const;

--- a/src/pages/onboarding/constants/index.ts
+++ b/src/pages/onboarding/constants/index.ts
@@ -32,7 +32,9 @@ export const MIN_NAME_LENGTH = 2;
 
 export const MAX_NAME_LENGTH = 8;
 
-export const MAX_VERFICATION_CODE = 6;
+export const MAX_VERIFICATION_CODE = 6;
+
+export const MAX_VERIFICATION_NUMBER = 5;
 
 export const MAX_PHONENUMBER_LENGTH = 11;
 
@@ -44,7 +46,6 @@ export const TIMER_DURATION = 300;
 
 export const REQUEST_DELAY = 10;
 
-// 인증번호 관련 유즈케이스 에러메세지
 export const PHONE_AUTH_MESSAGES = {
   TRY_AGAIN: '잠시 후 다시 요청해주세요',
   CODE_MISMATCH: '인증번호가 일치하지 않아요',

--- a/src/pages/onboarding/constants/index.ts
+++ b/src/pages/onboarding/constants/index.ts
@@ -32,7 +32,7 @@ export const MIN_NAME_LENGTH = 2;
 
 export const MAX_NAME_LENGTH = 8;
 
-export const MAX_VERFICATION_CODE = 4;
+export const MAX_VERFICATION_CODE = 6;
 
 export const MAX_PHONENUMBER_LENGTH = 11;
 

--- a/src/pages/onboarding/types/onboardInfoTypes.ts
+++ b/src/pages/onboarding/types/onboardInfoTypes.ts
@@ -9,3 +9,12 @@ export interface OnboardingState {
   isCodeVerified: boolean;
   isSubmitting: boolean;
 }
+
+export interface PhoneRequestTypes {
+  phoneNumber: string;
+}
+
+export interface phoneVerifyTypes {
+  phoneNumber: String;
+  code: string;
+}

--- a/src/pages/onboarding/types/onboardInfoTypes.ts
+++ b/src/pages/onboarding/types/onboardInfoTypes.ts
@@ -15,6 +15,6 @@ export interface PhoneRequestTypes {
 }
 
 export interface phoneVerifyTypes {
-  phoneNumber: String;
+  phoneNumber: string;
   code: string;
 }

--- a/src/shared/constants/apiURL.ts
+++ b/src/shared/constants/apiURL.ts
@@ -5,6 +5,8 @@ export const API_URL = {
   AUTH_LOGIN: '/api/v1/auth/login',
   AUTH_REISSUE: '/api/v1/auth/reissue',
   AUTH_LOGOUT: '/api/v1/auth/logout',
+  AUTH_PHONE_REQUEST: '/api/v1/auth/phone/request',
+  AUTH_PHONE_VERIFY: '/api/v1/auth/phone/verify',
 
   MEMBERS_WITHDRAW: '/api/v1/members/withdraw',
   MEMBERS_ONBOARD: '/api/v1/members/onboard',

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -3,3 +3,7 @@ export interface BankListResponseTypes {
   bankId: number;
   bankName: string;
 }
+
+export interface ApiError {
+  message: string;
+}


### PR DESCRIPTION
## 📌 Related Issues
- close #515

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks
- 기본 온보딩 api에서 이름, 번호를 제외한 필드를 없앴어요
- 인증번호 전송 관련 api를 추가해서 연결했어요
- 에러코드에 관한 각각 토스트 처리가 달라서 status 코드와 메세지에 맞게 notify가 뜨도록 설정했어요

## ⭐ PR Point 
 온보딩 과정의 휴대폰 인증 플로우를 완성하고, 다양한 예외 상황에 대한 사용자 피드백을 강화했습니다.

1. 인증 API 연동 및 상태 관리
usePostPhoneRequest와 usePostPhoneVerify 훅을 사용하여, '인증 요청' 및 '인증번호 확인' API를 연동했습니다.
isLoading 외에 requestCount 상태를 추가하여, 하루 5회까지만 인증을 요청할 수 있도록 비즈니스 로직을 구현했습니다.

2. 에러 핸들링
API 명세에 따라, onError 콜백 내에서 HTTP status 코드를 분기 처리하여 각 상황에 맞는 사용자 피드백을 제공하도록 구현했습니다.

- handleRequestVerification (인증번호 요청 시): 404 Not Found: "이미 등록된 전화번호에요"
- 기타 에러: "인증번호 전송에 실패했어요"
- handleVerifyCode (인증번호 확인 시): 409 Conflict: "인증번호가 일치하지 않아요"
- 400, 500 등 기타 서버 에러: 서버에서 전달된 에러 메시지를 그대로 토스트로 노출

3. 비즈니스 로직에 따른 예외 처리
API 에러 외에도, 사용자 경험을 해칠 수 있는 비즈니스 로직 상의 예외 케이스들을 아래와 같이 처리했습니다.

- 10초 이내 재요청 시: "잠시 후 다시 요청해주세요" 토스트 노출
- 5회 이상 요청 시: "인증 요청은 하루에 5회까지만 가능해요" 토스트 노출
- 인증 완료 후 재시도 시: "이미 인증이 완료되었어요" 토스트 노출
- 이를 통해 서버와의 통신 안정성을 높이고, 사용자가 어떤 상황에서도 명확한 피드백을 받을 수 있도록 피그마 반영했습니다

## 📷 Screenshot
<img width="436" height="103" alt="image" src="https://github.com/user-attachments/assets/2f9142af-6f31-4985-88c0-38ac9db860e3" />

<img width="650" height="336" alt="image" src="https://github.com/user-attachments/assets/7c60d729-1b42-457c-964d-e361b8a6ef4f" />
