### PR TITLE
[Fix] 마감 기한 지난 클래스 Tag 컴포넌트 비노출처리

### DIFF
--- a/src/pages/home/components/LessonItem/LessonItem.tsx
+++ b/src/pages/home/components/LessonItem/LessonItem.tsx
@@ -62,7 +62,7 @@ const LessonItem = ({
       className={clsx(styles.wrapper, sprinkles({ display: 'flex', flexDirection: 'column', gap: 8 }))}
       onClick={handleLessonClick}>
       <img src={imageUrl} alt="클래스 섬네일" className={styles.classImage} />
-      {remainingDays < 4 && (
+      {remainingDays < 4 && remainingDays >= 0 && (
         <Tag type="deadline" size="thumbnail" className={styles.deadlineTag}>
           {calculateRemainingDate(startDate, remainingDays)}
         </Tag>

--- a/src/pages/home/components/LessonItem/LessonItem.tsx
+++ b/src/pages/home/components/LessonItem/LessonItem.tsx
@@ -23,6 +23,7 @@ import Text from '@/shared/components/Text/Text';
 import { genreMapping, levelMapping } from '@/shared/constants';
 import { sprinkles } from '@/shared/styles/sprinkles.css';
 import { calculateRemainingDate } from '@/shared/utils/dateCalculate';
+import { MAX_REMAINING_DAYS, MIN_REMAINING_DAYS } from '@/pages/home/constants/index';
 
 const LessonItem = ({
   id,
@@ -62,7 +63,7 @@ const LessonItem = ({
       className={clsx(styles.wrapper, sprinkles({ display: 'flex', flexDirection: 'column', gap: 8 }))}
       onClick={handleLessonClick}>
       <img src={imageUrl} alt="클래스 섬네일" className={styles.classImage} />
-      {remainingDays < 4 && remainingDays >= 0 && (
+      {remainingDays < MAX_REMAINING_DAYS && remainingDays >= MIN_REMAINING_DAYS && (
         <Tag type="deadline" size="thumbnail" className={styles.deadlineTag}>
           {calculateRemainingDate(startDate, remainingDays)}
         </Tag>

--- a/src/pages/home/constants/index.tsx
+++ b/src/pages/home/constants/index.tsx
@@ -11,3 +11,7 @@ export const GENRE_ICONS = [
 export const MAX_POPULAR_GENRE_COUNT = 3;
 
 export const DUMMY = 'DUMMY';
+
+export const MAX_REMAINING_DAYS = 4;
+
+export const MIN_REMAINING_DAYS = 0;


### PR DESCRIPTION
## 📌 Related Issues
- close #544 

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks
- 기존에는 마감 기한 지난 클래스 들도 d-day로 표시가 되는 오류가 있었어요.  서버에서 -7과 같은 음수로 remainingDays를 내려주고 있는데, 음수에 대한 처리는 안되어 있었어요. 따라서 남은 일수가 0이상 이고, 4일 미만 일때만 Tag가 노출되게 수정했습니다. 

```ts
      {remainingDays < 4 && **_remainingDays >= 0_** && (
        <Tag type="deadline" size="thumbnail" className={styles.deadlineTag}>
          {calculateRemainingDate(startDate, remainingDays)}
        </Tag>
      )}
```


- 한줄 수정이라.. 리뷰 빠르게 부탁드려요 ㅎㅎ