### PR TITLE
[Design] 클래스 상세보기 레이아웃 수정, 클래스 개설 플로팅 버튼 수정

### DIFF
--- a/src/pages/mypage/components/TabWrapper/components/TeacherContent/teacherContent.css.ts
+++ b/src/pages/mypage/components/TabWrapper/components/TeacherContent/teacherContent.css.ts
@@ -28,9 +28,9 @@ export const classButtonStyle = style({
   alignItems: 'center',
   gap: '0.2rem',
 
-  position: 'fixed',    
-  right: '2rem',
-  bottom: '36px',
+  position: 'fixed',
+  right: `max(2rem, calc((100vw - var(--max-width)) / 2 + 2rem))`,
+  bottom: '3.6rem',
 
   width: 'max-content',
   padding: '1.2rem 1.6rem 1.2rem 1.2rem',

--- a/src/pages/mypage/components/TabWrapper/components/TeacherContent/teacherContent.css.ts
+++ b/src/pages/mypage/components/TabWrapper/components/TeacherContent/teacherContent.css.ts
@@ -28,7 +28,7 @@ export const classButtonStyle = style({
   alignItems: 'center',
   gap: '0.2rem',
 
-  position: 'absolute',
+  position: 'fixed',    
   right: '2rem',
   bottom: '36px',
 

--- a/src/pages/mypage/components/mypageReservationDetail/mypageReservationDetail.css.ts
+++ b/src/pages/mypage/components/mypageReservationDetail/mypageReservationDetail.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/shared/styles/theme.css';
 
 export const layoutStyle = style({
-  height: 'calc(100dvh - 6rem)',
+  height: '100%',
   padding: '3.3rem 2rem',
 
   backgroundColor: vars.colors.gray01,


### PR DESCRIPTION
## 📌 Related Issues
- close #546 

## ✅ 체크 리스트 
- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks
- 기존에 아마 클래스 상세보기 페이지가 스크롤이 될만큼 세로 영역이 차있지 않은데, height: 100%를 주면 기존에서 헤더 영역만큼 아래로 스크롤이 되어서 높이를 `height: 'calc(100dvh - 6rem)',` 다음과 같이 주고 있었었는데, 이제 스크롤이 되어야 해서 다시 100%로 고쳤습니다.
- 마이페이지 - 강사 탭 내 클래스 개설 플로팅 버튼 fixed로 변경했습니다. 그리고 디바이스 화면이 아닐때도 정확한 위치에 뜨기 위해서 right를 전체 뷰에서 max-width 만큼 빠지게 계산해서 추가했습니다.

## 📷 Screenshot
<img width="468" height="496" alt="image" src="https://github.com/user-attachments/assets/6ab1fed5-d1b3-4222-9f10-96681f737c4e" />

<img width="260" height="679" alt="image" src="https://github.com/user-attachments/assets/f3b3a792-2b8d-4942-958d-1c5524e08eeb" />

<img width="212" height="638" alt="image" src="https://github.com/user-attachments/assets/f057f19b-cbd3-46c8-b9af-b5595c236bcd" />
